### PR TITLE
feat: add APCA contrast algorithm toggle

### DIFF
--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -49,6 +49,10 @@ exports[`About > renders without crashing 1`] = `
   color: currentColor;
 }
 
+.emotion-15 {
+  font-weight: 700;
+}
+
 <main
     class="emotion-0"
   >
@@ -133,6 +137,71 @@ exports[`About > renders without crashing 1`] = `
           bold
         </strong>
          text that is 14pt or 18px and above, where the minimum contrast ratio can be 3.0:1
+      </p>
+      <p
+        class="emotion-3"
+      >
+        For AAA, push further: 7.0:1 for normal text, and 4.5:1 for that same large or bold text. This site reports AA and AAA against those thresholds as Small, Bold, and Large results.
+      </p>
+      <h2
+        class="emotion-15"
+      >
+        WCAG 2.x vs APCA
+      </h2>
+      <p
+        class="emotion-3"
+      >
+        Home and palette both let you switch the scoring algorithm. WCAG 2.x is the default and matches the contrast ratio rules above. APCA is a newer model that estimates how strongly text separates from its background for human vision, reported as a signed Lc (lightness contrast) value instead of a ratio like 4.5:1.
+      </p>
+      <p
+        class="emotion-3"
+      >
+        APCA does not use AA or AAA labels. Results here stay in the same Yup / Kinda / Nope voice, mapped from APCA readability bands rather than WCAG levels:
+      </p>
+      <p
+        class="emotion-3"
+      >
+        <strong>
+          Yup
+        </strong>
+         when Content text passes (|Lc| ≥ 60). 
+        <strong>
+          Kinda
+        </strong>
+         when Content fails but Large text passes (|Lc| ≥ 45). 
+        <strong>
+          Nope
+        </strong>
+         otherwise. 
+        <strong>
+          Seriously?
+        </strong>
+         still only appears for extreme fails (|Lc| under 15), as an overlay, never as the headline.
+      </p>
+      <p
+        class="emotion-3"
+      >
+        The readability rows use these absolute Lc thresholds from the APCA profile we ship:
+      </p>
+      <p
+        class="emotion-3"
+      >
+        Fluent text |Lc| ≥ 90
+        <br />
+        Body text |Lc| ≥ 75
+        <br />
+        Content text |Lc| ≥ 60
+        <br />
+        Large text |Lc| ≥ 45
+        <br />
+        Minimum text |Lc| ≥ 30
+        <br />
+        Non-text |Lc| ≥ 15
+      </p>
+      <p
+        class="emotion-3"
+      >
+        Body can fail under a Yup headline when Lc sits between 60 and 75. That is expected: the headline follows Content/Large, while each row reports its own band. APCA Lc is also directional, so swapping text and background can change the signed value and which bands pass.
       </p>
       <p
         class="emotion-3"

--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -207,9 +207,9 @@ exports[`About > renders without crashing 1`] = `
         , 
         <a
           class="emotion-6"
-          href="https://netlify.com"
+          href="https://www.cloudflare.com"
         >
-          hosted on Netlify
+          hosted on Cloudflare
         </a>
         .
       </p>

--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -141,67 +141,72 @@ exports[`About > renders without crashing 1`] = `
       <p
         class="emotion-3"
       >
-        For AAA, push further: 7.0:1 for normal text, and 4.5:1 for that same large or bold text. This site reports AA and AAA against those thresholds as Small, Bold, and Large results.
+        AAA is stricter. Normal text needs 7.0:1. Large or bold text needs 4.5:1. The Small, Bold and Large results show how your colours do at both AA and AAA.
       </p>
       <h2
         class="emotion-15"
       >
-        WCAG 2.x vs APCA
+        Two ways to score
       </h2>
       <p
         class="emotion-3"
       >
-        Home and palette both let you switch the scoring algorithm. WCAG 2.x is the default and matches the contrast ratio rules above. APCA is a newer model that estimates how strongly text separates from its background for human vision, reported as a signed Lc (lightness contrast) value instead of a ratio like 4.5:1.
+        WCAG 2.x is the default, but you can switch to APCA on the home page or the palette. APCA reports a signed Lc value for lightness contrast, not a ratio. It also skips AA and AAA labels.
       </p>
       <p
         class="emotion-3"
       >
-        APCA does not use AA or AAA labels. Results here stay in the same Yup / Kinda / Nope voice, mapped from APCA readability bands rather than WCAG levels:
-      </p>
-      <p
-        class="emotion-3"
-      >
+        The headline says 
         <strong>
           Yup
         </strong>
-         when Content text passes (|Lc| ≥ 60). 
+         when Content passes at |Lc| 60 or more. If Content misses but Large still passes at 45, it says 
         <strong>
           Kinda
         </strong>
-         when Content fails but Large text passes (|Lc| ≥ 45). 
+        . Below that, 
         <strong>
           Nope
         </strong>
-         otherwise. 
+        . When |Lc| drops under 15, 
         <strong>
           Seriously?
         </strong>
-         still only appears for extreme fails (|Lc| under 15), as an overlay, never as the headline.
+         shows up as a bit of extra heckling. It is not another headline.
       </p>
       <p
         class="emotion-3"
       >
-        The readability rows use these absolute Lc thresholds from the APCA profile we ship:
+        The APCA rows each have their own cut-off:
       </p>
       <p
         class="emotion-3"
       >
-        Fluent text |Lc| ≥ 90
+        Fluent |Lc| ≥ 90
         <br />
-        Body text |Lc| ≥ 75
+        Body |Lc| ≥ 75
         <br />
-        Content text |Lc| ≥ 60
+        Content |Lc| ≥ 60
         <br />
-        Large text |Lc| ≥ 45
+        Large |Lc| ≥ 45
         <br />
-        Minimum text |Lc| ≥ 30
+        Minimum |Lc| ≥ 30
         <br />
         Non-text |Lc| ≥ 15
       </p>
       <p
         class="emotion-3"
       >
-        Body can fail under a Yup headline when Lc sits between 60 and 75. That is expected: the headline follows Content/Large, while each row reports its own band. APCA Lc is also directional, so swapping text and background can change the signed value and which bands pass.
+        One odd bit: 
+        <strong>
+          Yup
+        </strong>
+         follows the Content mark, so Body can still fail when |Lc| is at least 60 but below 75. That is expected, even if it looks wrong at first glance.
+      </p>
+      <p
+        class="emotion-3"
+      >
+        Lc is directional too. Swap the text and background and the signed value, and which rows pass, can change.
       </p>
       <p
         class="emotion-3"

--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -163,11 +163,7 @@ exports[`About > renders without crashing 1`] = `
         <strong>
           Nope
         </strong>
-         is below that. 
-        <strong>
-          Seriously?
-        </strong>
-         is just a dig when contrast is awful.
+         is below that.
       </p>
       <p
         class="emotion-3"

--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -155,11 +155,11 @@ exports[`About > renders without crashing 1`] = `
         <strong>
           Yup
         </strong>
-         means Content passes (Lc 60+). 
+         means Body passes (Lc 75+). 
         <strong>
           Kinda
         </strong>
-         means only Large does (45+). 
+         means Content or Large still pass (60+ / 45+). 
         <strong>
           Nope
         </strong>

--- a/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/about/__tests__/__snapshots__/index.spec.tsx.snap
@@ -49,7 +49,7 @@ exports[`About > renders without crashing 1`] = `
   color: currentColor;
 }
 
-.emotion-15 {
+.emotion-14 {
   font-weight: 700;
 }
 
@@ -132,81 +132,47 @@ exports[`About > renders without crashing 1`] = `
       <p
         class="emotion-3"
       >
-        For text-based information to be perceivable by all users regardless of level of sight and to safely meet WCAG 2.0, AA requirements, you should aim for a minimum contrast ratio of 4.5:1 for all text content. There are 2 exceptions to this; large text that is 18pt or 24px and above or 
+        Aim for 4.5:1 to meet WCAG AA. Large text (18pt / 24px+) or 
         <strong>
           bold
         </strong>
-         text that is 14pt or 18px and above, where the minimum contrast ratio can be 3.0:1
-      </p>
-      <p
-        class="emotion-3"
-      >
-        AAA is stricter. Normal text needs 7.0:1. Large or bold text needs 4.5:1. The Small, Bold and Large results show how your colours do at both AA and AAA.
+         text (14pt / 18px+) can pass at 3:1. AAA wants 7:1 for normal text and 4.5:1 for large or bold. Small, Bold and Large show how you do at both.
       </p>
       <h2
-        class="emotion-15"
+        class="emotion-14"
       >
-        Two ways to score
+        Two algorithms
       </h2>
       <p
         class="emotion-3"
       >
-        WCAG 2.x is the default, but you can switch to APCA on the home page or the palette. APCA reports a signed Lc value for lightness contrast, not a ratio. It also skips AA and AAA labels.
+        This site uses WCAG 2 and APCA. Flip between them on the home page or the palette. WCAG gives a contrast ratio with AA/AAA. APCA gives an Lc score instead.
       </p>
       <p
         class="emotion-3"
       >
-        The headline says 
+        For APCA, 
         <strong>
           Yup
         </strong>
-         when Content passes at |Lc| 60 or more. If Content misses but Large still passes at 45, it says 
+         means Content passes (Lc 60+). 
         <strong>
           Kinda
         </strong>
-        . Below that, 
+         means only Large does (45+). 
         <strong>
           Nope
         </strong>
-        . When |Lc| drops under 15, 
+         is below that. 
         <strong>
           Seriously?
         </strong>
-         shows up as a bit of extra heckling. It is not another headline.
+         is just a dig when contrast is awful.
       </p>
       <p
         class="emotion-3"
       >
-        The APCA rows each have their own cut-off:
-      </p>
-      <p
-        class="emotion-3"
-      >
-        Fluent |Lc| ≥ 90
-        <br />
-        Body |Lc| ≥ 75
-        <br />
-        Content |Lc| ≥ 60
-        <br />
-        Large |Lc| ≥ 45
-        <br />
-        Minimum |Lc| ≥ 30
-        <br />
-        Non-text |Lc| ≥ 15
-      </p>
-      <p
-        class="emotion-3"
-      >
-        One odd bit: 
-        <strong>
-          Yup
-        </strong>
-         follows the Content mark, so Body can still fail when |Lc| is at least 60 but below 75. That is expected, even if it looks wrong at first glance.
-      </p>
-      <p
-        class="emotion-3"
-      >
-        Lc is directional too. Swap the text and background and the signed value, and which rows pass, can change.
+        APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.
       </p>
       <p
         class="emotion-3"

--- a/src/components/about/__tests__/index.spec.tsx
+++ b/src/components/about/__tests__/index.spec.tsx
@@ -1,9 +1,19 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { About } from "..";
 
 describe("About", (): void => {
   it("renders without crashing", (): void => {
     const { asFragment } = render(<About />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("explains APCA scoring and thresholds", (): void => {
+    render(<About />);
+
+    expect(screen.getByRole("heading", { name: "WCAG 2.x vs APCA" })).toBeTruthy();
+    expect(screen.getByText(/signed Lc \(lightness contrast\) value/i)).toBeTruthy();
+    expect(screen.getByText(/Content text passes \(\|Lc\| ≥ 60\)/i)).toBeTruthy();
+    expect(screen.getByText(/Fluent text \|Lc\| ≥ 90/i)).toBeTruthy();
+    expect(screen.getByText(/Non-text \|Lc\| ≥ 15/i)).toBeTruthy();
   });
 });

--- a/src/components/about/__tests__/index.spec.tsx
+++ b/src/components/about/__tests__/index.spec.tsx
@@ -7,13 +7,12 @@ describe("About", (): void => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it("explains APCA scoring and thresholds", (): void => {
+  it("explains how to read WCAG and APCA scores", (): void => {
     render(<About />);
 
-    expect(screen.getByRole("heading", { name: "Two ways to score" })).toBeTruthy();
-    expect(screen.getByText(/signed Lc value for lightness contrast/i)).toBeTruthy();
-    expect(screen.getByText(/Content passes at \|Lc\| 60 or more/i)).toBeTruthy();
-    expect(screen.getByText(/Fluent \|Lc\| ≥ 90/i)).toBeTruthy();
-    expect(screen.getByText(/Non-text \|Lc\| ≥ 15/i)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Two algorithms" })).toBeTruthy();
+    expect(screen.getByText(/This site uses WCAG 2 and APCA/i)).toBeTruthy();
+    expect(screen.getByText(/Yup/)).toBeTruthy();
+    expect(screen.getByText(/Fluent 90/i)).toBeTruthy();
   });
 });

--- a/src/components/about/__tests__/index.spec.tsx
+++ b/src/components/about/__tests__/index.spec.tsx
@@ -10,10 +10,10 @@ describe("About", (): void => {
   it("explains APCA scoring and thresholds", (): void => {
     render(<About />);
 
-    expect(screen.getByRole("heading", { name: "WCAG 2.x vs APCA" })).toBeTruthy();
-    expect(screen.getByText(/signed Lc \(lightness contrast\) value/i)).toBeTruthy();
-    expect(screen.getByText(/Content text passes \(\|Lc\| ≥ 60\)/i)).toBeTruthy();
-    expect(screen.getByText(/Fluent text \|Lc\| ≥ 90/i)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Two ways to score" })).toBeTruthy();
+    expect(screen.getByText(/signed Lc value for lightness contrast/i)).toBeTruthy();
+    expect(screen.getByText(/Content passes at \|Lc\| 60 or more/i)).toBeTruthy();
+    expect(screen.getByText(/Fluent \|Lc\| ≥ 90/i)).toBeTruthy();
     expect(screen.getByText(/Non-text \|Lc\| ≥ 15/i)).toBeTruthy();
   });
 });

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -63,45 +63,42 @@ const About: React.FC = (): ReactElement => (
         contrast ratio can be 3.0:1
       </P>
       <P>
-        For AAA, push further: 7.0:1 for normal text, and 4.5:1 for that same large or bold text.
-        This site reports AA and AAA against those thresholds as Small, Bold, and Large results.
+        AAA is stricter. Normal text needs 7.0:1. Large or bold text needs 4.5:1. The Small, Bold
+        and Large results show how your colours do at both AA and AAA.
       </P>
-      <Heading as="h2">WCAG 2.x vs APCA</Heading>
+      <Heading as="h2">Two ways to score</Heading>
       <P>
-        Home and palette both let you switch the scoring algorithm. WCAG 2.x is the default and
-        matches the contrast ratio rules above. APCA is a newer model that estimates how strongly
-        text separates from its background for human vision, reported as a signed Lc (lightness
-        contrast) value instead of a ratio like 4.5:1.
-      </P>
-      <P>
-        APCA does not use AA or AAA labels. Results here stay in the same Yup / Kinda / Nope voice,
-        mapped from APCA readability bands rather than WCAG levels:
+        WCAG 2.x is the default, but you can switch to APCA on the home page or the palette. APCA
+        reports a signed Lc value for lightness contrast, not a ratio. It also skips AA and AAA
+        labels.
       </P>
       <P>
-        <strong>Yup</strong> when Content text passes (|Lc| ≥ 60). <strong>Kinda</strong> when
-        Content fails but Large text passes (|Lc| ≥ 45). <strong>Nope</strong> otherwise.{" "}
-        <strong>Seriously?</strong> still only appears for extreme fails (|Lc| under 15), as an
-        overlay, never as the headline.
+        The headline says <strong>Yup</strong> when Content passes at |Lc| 60 or more. If Content
+        misses but Large still passes at 45, it says <strong>Kinda</strong>. Below that,{" "}
+        <strong>Nope</strong>. When |Lc| drops under 15, <strong>Seriously?</strong> shows up as a
+        bit of extra heckling. It is not another headline.
       </P>
-      <P>The readability rows use these absolute Lc thresholds from the APCA profile we ship:</P>
+      <P>The APCA rows each have their own cut-off:</P>
       <P>
-        Fluent text |Lc| ≥ 90
+        Fluent |Lc| ≥ 90
         <br />
-        Body text |Lc| ≥ 75
+        Body |Lc| ≥ 75
         <br />
-        Content text |Lc| ≥ 60
+        Content |Lc| ≥ 60
         <br />
-        Large text |Lc| ≥ 45
+        Large |Lc| ≥ 45
         <br />
-        Minimum text |Lc| ≥ 30
+        Minimum |Lc| ≥ 30
         <br />
         Non-text |Lc| ≥ 15
       </P>
       <P>
-        Body can fail under a Yup headline when Lc sits between 60 and 75. That is expected: the
-        headline follows Content/Large, while each row reports its own band. APCA Lc is also
-        directional, so swapping text and background can change the signed value and which bands
-        pass.
+        One odd bit: <strong>Yup</strong> follows the Content mark, so Body can still fail when |Lc|
+        is at least 60 but below 75. That is expected, even if it looks wrong at first glance.
+      </P>
+      <P>
+        Lc is directional too. Swap the text and background and the signed value, and which rows
+        pass, can change.
       </P>
       <P>
         Building upon and heavily influenced by the excellent{" "}

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -63,6 +63,47 @@ const About: React.FC = (): ReactElement => (
         contrast ratio can be 3.0:1
       </P>
       <P>
+        For AAA, push further: 7.0:1 for normal text, and 4.5:1 for that same large or bold text.
+        This site reports AA and AAA against those thresholds as Small, Bold, and Large results.
+      </P>
+      <Heading as="h2">WCAG 2.x vs APCA</Heading>
+      <P>
+        Home and palette both let you switch the scoring algorithm. WCAG 2.x is the default and
+        matches the contrast ratio rules above. APCA is a newer model that estimates how strongly
+        text separates from its background for human vision, reported as a signed Lc (lightness
+        contrast) value instead of a ratio like 4.5:1.
+      </P>
+      <P>
+        APCA does not use AA or AAA labels. Results here stay in the same Yup / Kinda / Nope voice,
+        mapped from APCA readability bands rather than WCAG levels:
+      </P>
+      <P>
+        <strong>Yup</strong> when Content text passes (|Lc| ≥ 60). <strong>Kinda</strong> when
+        Content fails but Large text passes (|Lc| ≥ 45). <strong>Nope</strong> otherwise.{" "}
+        <strong>Seriously?</strong> still only appears for extreme fails (|Lc| under 15), as an
+        overlay, never as the headline.
+      </P>
+      <P>The readability rows use these absolute Lc thresholds from the APCA profile we ship:</P>
+      <P>
+        Fluent text |Lc| ≥ 90
+        <br />
+        Body text |Lc| ≥ 75
+        <br />
+        Content text |Lc| ≥ 60
+        <br />
+        Large text |Lc| ≥ 45
+        <br />
+        Minimum text |Lc| ≥ 30
+        <br />
+        Non-text |Lc| ≥ 15
+      </P>
+      <P>
+        Body can fail under a Yup headline when Lc sits between 60 and 75. That is expected: the
+        headline follows Content/Large, while each row reports its own band. APCA Lc is also
+        directional, so swapping text and background can change the signed value and which bands
+        pass.
+      </P>
+      <P>
         Building upon and heavily influenced by the excellent{" "}
         <Link href="http://jxnblk.com/colorable/">Colorable</Link>, I wanted more context around the
         result. When you share the outcome with your colleagues, all the results, rules and what

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -81,7 +81,7 @@ const About: React.FC = (): ReactElement => (
       <P>
         Built by <Link href="http://www.simontaggart.com">Simon Taggart</Link>,{" "}
         <Link href="https://github.com/SiTaggart/AreMyColorsAccessible">code on GitHub</Link>,{" "}
-        <Link href="https://netlify.com">hosted on Netlify</Link>.
+        <Link href="https://www.cloudflare.com">hosted on Cloudflare</Link>.
       </P>
     </Layout>
   </Container>

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -66,8 +66,8 @@ const About: React.FC = (): ReactElement => (
         gives a contrast ratio with AA/AAA. APCA gives an Lc score instead.
       </P>
       <P>
-        For APCA, <strong>Yup</strong> means Content passes (Lc 60+). <strong>Kinda</strong> means
-        only Large does (45+). <strong>Nope</strong> is below that.
+        For APCA, <strong>Yup</strong> means Body passes (Lc 75+). <strong>Kinda</strong> means
+        Content or Large still pass (60+ / 45+). <strong>Nope</strong> is below that.
       </P>
       <P>APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.</P>
       <P>

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -67,8 +67,7 @@ const About: React.FC = (): ReactElement => (
       </P>
       <P>
         For APCA, <strong>Yup</strong> means Content passes (Lc 60+). <strong>Kinda</strong> means
-        only Large does (45+). <strong>Nope</strong> is below that. <strong>Seriously?</strong> is
-        just a dig when contrast is awful.
+        only Large does (45+). <strong>Nope</strong> is below that.
       </P>
       <P>APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.</P>
       <P>

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -70,9 +70,7 @@ const About: React.FC = (): ReactElement => (
         only Large does (45+). <strong>Nope</strong> is below that. <strong>Seriously?</strong> is
         just a dig when contrast is awful.
       </P>
-      <P>
-        APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.
-      </P>
+      <P>APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.</P>
       <P>
         Building upon and heavily influenced by the excellent{" "}
         <Link href="http://jxnblk.com/colorable/">Colorable</Link>, I wanted more context around the

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -56,49 +56,22 @@ const About: React.FC = (): ReactElement => (
         </P>
       </Blockquote>
       <P>
-        For text-based information to be perceivable by all users regardless of level of sight and
-        to safely meet WCAG 2.0, AA requirements, you should aim for a minimum contrast ratio of
-        4.5:1 for all text content. There are 2 exceptions to this; large text that is 18pt or 24px
-        and above or <strong>bold</strong> text that is 14pt or 18px and above, where the minimum
-        contrast ratio can be 3.0:1
+        Aim for 4.5:1 to meet WCAG AA. Large text (18pt / 24px+) or <strong>bold</strong> text (14pt
+        / 18px+) can pass at 3:1. AAA wants 7:1 for normal text and 4.5:1 for large or bold. Small,
+        Bold and Large show how you do at both.
+      </P>
+      <Heading as="h2">Two algorithms</Heading>
+      <P>
+        This site uses WCAG 2 and APCA. Flip between them on the home page or the palette. WCAG
+        gives a contrast ratio with AA/AAA. APCA gives an Lc score instead.
       </P>
       <P>
-        AAA is stricter. Normal text needs 7.0:1. Large or bold text needs 4.5:1. The Small, Bold
-        and Large results show how your colours do at both AA and AAA.
-      </P>
-      <Heading as="h2">Two ways to score</Heading>
-      <P>
-        WCAG 2.x is the default, but you can switch to APCA on the home page or the palette. APCA
-        reports a signed Lc value for lightness contrast, not a ratio. It also skips AA and AAA
-        labels.
+        For APCA, <strong>Yup</strong> means Content passes (Lc 60+). <strong>Kinda</strong> means
+        only Large does (45+). <strong>Nope</strong> is below that. <strong>Seriously?</strong> is
+        just a dig when contrast is awful.
       </P>
       <P>
-        The headline says <strong>Yup</strong> when Content passes at |Lc| 60 or more. If Content
-        misses but Large still passes at 45, it says <strong>Kinda</strong>. Below that,{" "}
-        <strong>Nope</strong>. When |Lc| drops under 15, <strong>Seriously?</strong> shows up as a
-        bit of extra heckling. It is not another headline.
-      </P>
-      <P>The APCA rows each have their own cut-off:</P>
-      <P>
-        Fluent |Lc| ≥ 90
-        <br />
-        Body |Lc| ≥ 75
-        <br />
-        Content |Lc| ≥ 60
-        <br />
-        Large |Lc| ≥ 45
-        <br />
-        Minimum |Lc| ≥ 30
-        <br />
-        Non-text |Lc| ≥ 15
-      </P>
-      <P>
-        One odd bit: <strong>Yup</strong> follows the Content mark, so Body can still fail when |Lc|
-        is at least 60 but below 75. That is expected, even if it looks wrong at first glance.
-      </P>
-      <P>
-        Lc is directional too. Swap the text and background and the signed value, and which rows
-        pass, can change.
+        APCA row targets: Fluent 90, Body 75, Content 60, Large 45, Minimum 30, Non-Text 15.
       </P>
       <P>
         Building upon and heavily influenced by the excellent{" "}

--- a/src/components/color-card/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/color-card/__tests__/__snapshots__/index.spec.tsx.snap
@@ -68,7 +68,7 @@ exports[`ColorCard > renders without crashing 1`] = `
     >
       <span
         class="emotion-2"
-        title="Color contrast ratio"
+        title="Contrast Ratio"
       >
         21 : 1
       </span>
@@ -171,7 +171,7 @@ exports[`ColorCard > should render a not important card 1`] = `
     >
       <span
         class="emotion-2"
-        title="Color contrast ratio"
+        title="Contrast Ratio"
       >
         21 : 1
       </span>

--- a/src/components/color-card/__tests__/index.spec.tsx
+++ b/src/components/color-card/__tests__/index.spec.tsx
@@ -3,14 +3,14 @@ import { ColorCard, ColorCardProps } from "..";
 
 describe("ColorCard", (): void => {
   const mockProps: ColorCardProps = {
-    accessibility: {
-      aa: true,
-      aaa: true,
-      aaaLarge: true,
-      aaLarge: true,
-    },
     color: "#000",
-    contrast: 21,
+    heading: "Yup",
+    metricLabel: "Contrast Ratio",
+    metricValue: "21 : 1",
+    rows: [
+      { label: "Small", meets: true, value: "AAA" },
+      { label: "Large", meets: true, value: "AAA" },
+    ],
   };
 
   it("renders without crashing", (): void => {

--- a/src/components/color-card/index.tsx
+++ b/src/components/color-card/index.tsx
@@ -1,12 +1,12 @@
 import React, { ReactElement } from "react";
 import styled, { CSSObject } from "@emotion/styled";
-import { Levels } from "../../types";
-import { colorRating } from "../../utils/color-rating";
+import type { ContrastDisplayResult } from "../../utils/contrast-results";
 
-export interface ColorCardProps {
-  accessibility: Levels;
+export interface ColorCardProps extends Pick<
+  ContrastDisplayResult,
+  "heading" | "metricLabel" | "metricValue" | "rows"
+> {
   color: string;
-  contrast: number;
   isNotImportant?: boolean;
 }
 
@@ -66,32 +66,29 @@ const StyledColorCardPill = styled.span<StyledColorCardPillProps>`
 `;
 
 const ColorCard: React.FC<ColorCardProps> = ({
-  accessibility,
   color,
-  contrast,
+  heading,
   isNotImportant,
+  metricLabel,
+  metricValue,
+  rows,
 }: ColorCardProps): ReactElement<HTMLDivElement> => {
-  const rating = colorRating(accessibility);
-
   return (
     <StyledColorCard data-testid="colorCard" isNotImportant={isNotImportant}>
       <StyledCardRow>
-        <StyledColorCardPill title="Color contrast ratio">
-          {Number.parseFloat(contrast.toFixed(2))} : 1
-        </StyledColorCardPill>
+        <StyledColorCardPill title={metricLabel}>{metricValue}</StyledColorCardPill>
       </StyledCardRow>
       <StyledCardRow>
         <StyledColorSwatch color={color} data-testid="colorCard-swatch">
-          {rating.overall}
+          {heading}
         </StyledColorSwatch>
       </StyledCardRow>
       <StyledCardRow>
-        <StyledColorCardPill status={rating.small === "Fail" ? "error" : "success"}>
-          Small: {rating.small}
-        </StyledColorCardPill>
-        <StyledColorCardPill status={rating.large === "Fail" ? "error" : "success"}>
-          Large: {rating.large}
-        </StyledColorCardPill>
+        {rows.map((row) => (
+          <StyledColorCardPill key={row.label} status={row.meets ? "success" : "error"}>
+            {row.label}: {row.value}
+          </StyledColorCardPill>
+        ))}
       </StyledCardRow>
     </StyledColorCard>
   );

--- a/src/components/color-matrix/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/color-matrix/__tests__/__snapshots__/index.spec.tsx.snap
@@ -732,7 +732,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   1.61 : 1
                 </span>
@@ -777,7 +777,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   4.48 : 1
                 </span>
@@ -822,7 +822,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   21 : 1
                 </span>
@@ -879,7 +879,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   1.61 : 1
                 </span>
@@ -929,7 +929,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   2.79 : 1
                 </span>
@@ -974,7 +974,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   13.08 : 1
                 </span>
@@ -1031,7 +1031,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   4.48 : 1
                 </span>
@@ -1076,7 +1076,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   2.79 : 1
                 </span>
@@ -1126,7 +1126,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   4.69 : 1
                 </span>
@@ -1183,7 +1183,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   21 : 1
                 </span>
@@ -1228,7 +1228,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   13.08 : 1
                 </span>
@@ -1273,7 +1273,7 @@ exports[`ColorMatrix > renders without crashing 1`] = `
               >
                 <span
                   class="emotion-81"
-                  title="Color contrast ratio"
+                  title="Contrast Ratio"
                 >
                   4.69 : 1
                 </span>

--- a/src/components/color-matrix/__tests__/index.spec.tsx
+++ b/src/components/color-matrix/__tests__/index.spec.tsx
@@ -9,6 +9,7 @@ describe("ColorMatrix", (): void => {
 
   if (mockColorColorCombos !== false) {
     mockProps = {
+      algorithm: "wcag2",
       colorCombos: mockColorColorCombos,
       colors: ["#fff", "#ccc", "#777", "#000"],
       onColorChange: onColorChangeMock,
@@ -30,5 +31,26 @@ describe("ColorMatrix", (): void => {
     const { getByTestId } = render(<ColorMatrix {...mockProps} />);
     fireEvent.change(getByTestId("hsl-0-Lightness"), { target: { value: "12" } });
     expect(onColorChangeMock).toHaveBeenCalledWith("#1F1F1F", 0);
+  });
+
+  it("renders directional APCA card results", (): void => {
+    const colorCombos = ColorCombos(["#fff", "#000"]);
+    if (colorCombos === false) {
+      throw new Error("Expected valid color combinations");
+    }
+
+    const { getAllByText, getAllByTitle } = render(
+      <ColorMatrix
+        algorithm="apca"
+        colorCombos={colorCombos}
+        colors={["#fff", "#000"]}
+        onColorChange={onColorChangeMock}
+      />,
+    );
+
+    expect(getAllByText(/Body:/)).toHaveLength(2);
+    const metricValues = getAllByTitle("APCA Lc").map((element) => element.textContent);
+    expect(metricValues).toHaveLength(2);
+    expect(metricValues[0]).not.toBe(metricValues[1]);
   });
 });

--- a/src/components/color-matrix/index.tsx
+++ b/src/components/color-matrix/index.tsx
@@ -5,8 +5,11 @@ import { ColorCombo } from "color-combos";
 import { ColorCard } from "../color-card";
 import { FormInput } from "../form-input";
 import { HslSliders } from "../hsl-sliders";
+import type { ContrastAlgorithm } from "../../types";
+import { getContrastDisplayResult } from "../../utils/contrast-results";
 
 export interface ColorMatrixProps {
+  algorithm: ContrastAlgorithm;
   colorCombos: Array<ColorCombo>;
   colors: Array<string>;
   onColorChange: (newColor: string, index: number) => void;
@@ -35,6 +38,7 @@ const StyledColorMatrixTd = styled.td`
 `;
 
 const ColorMatrix: React.FC<ColorMatrixProps> = ({
+  algorithm,
   colorCombos,
   colors,
   onColorChange,
@@ -80,8 +84,9 @@ const ColorMatrix: React.FC<ColorMatrixProps> = ({
               <StyledColorMatrixTh data-testid="colorMatrix-th" scope="row">
                 {color.hex}
               </StyledColorMatrixTh>
-              {color.combinations.map(
-                (combo, comboIndex): ReactElement => (
+              {color.combinations.map((combo, comboIndex): ReactElement => {
+                const result = getContrastDisplayResult(combo, algorithm, "compact");
+                return (
                   <React.Fragment key={comboIndex}>
                     {index === comboIndex && <StyledColorMatrixTd>&nbsp;</StyledColorMatrixTd>}
                     <StyledColorMatrixTd
@@ -90,14 +95,16 @@ const ColorMatrix: React.FC<ColorMatrixProps> = ({
                       }}
                     >
                       <ColorCard
-                        accessibility={combo.accessibility!}
                         color={color.hex}
-                        contrast={combo.contrast!}
+                        heading={result.heading}
+                        metricLabel={result.metricLabel}
+                        metricValue={result.metricValue}
+                        rows={result.rows}
                       />
                     </StyledColorMatrixTd>
                   </React.Fragment>
-                ),
-              )}
+                );
+              })}
             </StyledColorMatrixTr>
           ),
         )}

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -189,20 +189,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
   color: inherit;
   margin: 0;
   min-width: 0;
-  padding: 1rem;
+  padding: 0 1rem 1rem;
   text-align: center;
   width: 100%;
 }
 
 .emotion-40 {
   display: block;
+  float: left;
   font-size: 1.2rem;
-  margin: 0 0 10px;
+  line-height: 1;
+  margin: 0 0 5px;
   padding: 0;
   width: 100%;
 }
 
 .emotion-41 {
+  clear: both;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -225,7 +228,8 @@ exports[`ColorInputs > renders without crashing 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1.2rem;
-  line-height: 1.4;
+  line-height: 1;
+  padding-bottom: 0.35em;
   position: relative;
   -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
   transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
@@ -236,7 +240,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 2px;
-  text-underline-offset: 0.3em;
+  text-underline-offset: 0.2em;
 }
 
 .emotion-42:has(input:focus-visible) {

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -399,6 +399,28 @@ exports[`ColorInputs > renders without crashing 1`] = `
         </div>
       </div>
     </div>
+    <fieldset>
+      <legend>
+        Contrast algorithm
+      </legend>
+      <label>
+        <input
+          checked=""
+          name="contrast-algorithm"
+          type="radio"
+          value="wcag2"
+        />
+        WCAG 2.x
+      </label>
+      <label>
+        <input
+          name="contrast-algorithm"
+          type="radio"
+          value="apca"
+        />
+        APCA
+      </label>
+    </fieldset>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -19,24 +19,190 @@ exports[`ColorInputs > renders without crashing 1`] = `
 }
 
 .emotion-1 {
+  padding: 1rem;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .emotion-1 {
+    -webkit-flex: 1 1 auto;
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+    width: 50%;
+  }
+}
+
+.emotion-2 {
+  display: inline-block;
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.emotion-3 {
+  background: rgba(255, 255, 255, 0.1);
+  border: solid 1px;
+  border-radius: 3px;
+  font-size: 1.2rem;
+  padding: 0.5rem 1rem;
+  margin-bottom: 2rem;
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 1024px) {
+  .emotion-4 {
+    margin: 0 -0.5rem;
+  }
+}
+
+.emotion-5 {
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .emotion-5 {
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    padding: 0 0.5rem;
+    width: 33.3333%;
+  }
+}
+
+.emotion-9 {
+  -webkit-appearance: none;
+  background: transparent;
+  border-radius: 2px;
+  color: currentColor;
+  display: block;
+  margin: 10px 0;
+  width: 100%;
+}
+
+.emotion-9::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px;
+}
+
+.emotion-9::-webkit-slider-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-top: -9px;
+}
+
+.emotion-9:focus::-webkit-slider-runnable-track {
+  background: currentColor;
+}
+
+.emotion-9::-moz-range-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px;
+}
+
+.emotion-9::-moz-range-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+}
+
+.emotion-9::-ms-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  background: transparent;
+  border-color: transparent;
+  border-width: 8px 0;
+  color: transparent;
+}
+
+.emotion-9::-ms-fill-lower {
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px * 2;
+}
+
+.emotion-9::-ms-fill-upper {
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px * 2;
+}
+
+.emotion-9::-ms-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+}
+
+.emotion-9:focus::-ms-fill-lower {
+  background: currentColor;
+}
+
+.emotion-9:focus::-ms-fill-upper {
+  background: currentColor;
+}
+
+.emotion-39 {
   border: 0;
   color: inherit;
   margin: 0;
   min-width: 0;
   padding: 1rem;
-  text-align: start;
+  text-align: center;
   width: 100%;
 }
 
-.emotion-2 {
+.emotion-40 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.15rem;
   padding: 0;
   width: 100%;
 }
 
-.emotion-3 {
+.emotion-41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -46,13 +212,13 @@ exports[`ColorInputs > renders without crashing 1`] = `
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   gap: 1.25rem;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
-.emotion-4 {
+.emotion-42 {
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -65,7 +231,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
 }
 
-.emotion-4:has(input:checked) {
+.emotion-42:has(input:checked) {
   font-weight: 700;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -73,12 +239,12 @@ exports[`ColorInputs > renders without crashing 1`] = `
   text-underline-offset: 0.3em;
 }
 
-.emotion-4:has(input:focus-visible) {
+.emotion-42:has(input:focus-visible) {
   outline: currentColor dashed 2px;
   outline-offset: 3px;
 }
 
-.emotion-5 {
+.emotion-43 {
   cursor: pointer;
   height: 100%;
   left: 0;
@@ -89,225 +255,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
   width: 100%;
 }
 
-.emotion-8 {
-  padding: 1rem;
-  width: 100%;
-}
-
-@media (min-width: 768px) {
-  .emotion-8 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
-    width: 50%;
-  }
-}
-
-.emotion-9 {
-  display: inline-block;
-  font-size: 1.2rem;
-  margin-bottom: 0.5rem;
-  width: 100%;
-}
-
-.emotion-10 {
-  background: rgba(255, 255, 255, 0.1);
-  border: solid 1px;
-  border-radius: 3px;
-  font-size: 1.2rem;
-  padding: 0.5rem 1rem;
-  margin-bottom: 2rem;
-  width: 100%;
-}
-
-.emotion-11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
-@media (min-width: 1024px) {
-  .emotion-11 {
-    margin: 0 -0.5rem;
-  }
-}
-
-.emotion-12 {
-  width: 100%;
-}
-
-@media (min-width: 1024px) {
-  .emotion-12 {
-    -webkit-flex: 1 0 auto;
-    -ms-flex: 1 0 auto;
-    flex: 1 0 auto;
-    padding: 0 0.5rem;
-    width: 33.3333%;
-  }
-}
-
-.emotion-16 {
-  -webkit-appearance: none;
-  background: transparent;
-  border-radius: 2px;
-  color: currentColor;
-  display: block;
-  margin: 10px 0;
-  width: 100%;
-}
-
-.emotion-16::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px;
-}
-
-.emotion-16::-webkit-slider-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-  -webkit-appearance: none;
-  margin-top: -9px;
-}
-
-.emotion-16:focus::-webkit-slider-runnable-track {
-  background: currentColor;
-}
-
-.emotion-16::-moz-range-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px;
-}
-
-.emotion-16::-moz-range-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-}
-
-.emotion-16::-ms-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  background: transparent;
-  border-color: transparent;
-  border-width: 8px 0;
-  color: transparent;
-}
-
-.emotion-16::-ms-fill-lower {
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px * 2;
-}
-
-.emotion-16::-ms-fill-upper {
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px * 2;
-}
-
-.emotion-16::-ms-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-}
-
-.emotion-16:focus::-ms-fill-lower {
-  background: currentColor;
-}
-
-.emotion-16:focus::-ms-fill-upper {
-  background: currentColor;
-}
-
 <div
     class="emotion-0"
     data-testid="color-input-form"
     style="color: rgb(255, 255, 255);"
   >
-    <fieldset
+    <div
       class="emotion-1"
     >
-      <legend
-        class="emotion-2"
-      >
-        Algorithm
-      </legend>
-      <div
-        class="emotion-3"
-      >
-        <label
-          class="emotion-4"
-        >
-          <input
-            checked=""
-            class="emotion-5"
-            name="contrast-algorithm"
-            type="radio"
-            value="wcag2"
-          />
-          WCAG 2.x
-        </label>
-        <label
-          class="emotion-4"
-        >
-          <input
-            class="emotion-5"
-            name="contrast-algorithm"
-            type="radio"
-            value="apca"
-          />
-          APCA
-        </label>
-      </div>
-    </fieldset>
-    <div
-      class="emotion-8"
-    >
       <label
-        class="emotion-9"
+        class="emotion-2"
         for="textColor"
       >
         Text Color
       </label>
       <input
         autocomplete="off"
-        class="emotion-10"
+        class="emotion-3"
         data-testid="textColor"
         id="textColor"
         style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -315,27 +279,27 @@ exports[`ColorInputs > renders without crashing 1`] = `
         value="#fff"
       />
       <div
-        class="emotion-11"
+        class="emotion-4"
         data-testid="form-hsl-sliders"
       >
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="textColor-hsl-Hue"
             >
               Hue 0°
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="textColor-hsl-Hue"
               id="textColor-hsl-Hue"
               max="360"
@@ -346,23 +310,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="textColor-hsl-Saturation"
             >
               Saturation 0%
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="textColor-hsl-Saturation"
               id="textColor-hsl-Saturation"
               max="100"
@@ -373,23 +337,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="textColor-hsl-Lightness"
             >
               Lightness 100%
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="textColor-hsl-Lightness"
               id="textColor-hsl-Lightness"
               max="100"
@@ -402,17 +366,17 @@ exports[`ColorInputs > renders without crashing 1`] = `
       </div>
     </div>
     <div
-      class="emotion-8"
+      class="emotion-1"
     >
       <label
-        class="emotion-9"
+        class="emotion-2"
         for="background"
       >
         Background
       </label>
       <input
         autocomplete="off"
-        class="emotion-10"
+        class="emotion-3"
         data-testid="background"
         id="background"
         style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -420,27 +384,27 @@ exports[`ColorInputs > renders without crashing 1`] = `
         value="#000"
       />
       <div
-        class="emotion-11"
+        class="emotion-4"
         data-testid="form-hsl-sliders"
       >
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="background-hsl-Hue"
             >
               Hue 0°
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="background-hsl-Hue"
               id="background-hsl-Hue"
               max="360"
@@ -451,23 +415,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="background-hsl-Saturation"
             >
               Saturation 0%
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="background-hsl-Saturation"
               id="background-hsl-Saturation"
               max="100"
@@ -478,23 +442,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-12"
+          class="emotion-5"
         >
           <div
-            class="emotion-13"
+            class="emotion-6"
           >
             <label
-              class="emotion-9"
+              class="emotion-2"
               for="background-hsl-Lightness"
             >
               Lightness 0%
             </label>
           </div>
           <div
-            class="emotion-15"
+            class="emotion-8"
           >
             <input
-              class="emotion-16"
+              class="emotion-9"
               data-testid="background-hsl-Lightness"
               id="background-hsl-Lightness"
               max="100"
@@ -506,6 +470,42 @@ exports[`ColorInputs > renders without crashing 1`] = `
         </div>
       </div>
     </div>
+    <fieldset
+      class="emotion-39"
+    >
+      <legend
+        class="emotion-40"
+      >
+        Algorithm
+      </legend>
+      <div
+        class="emotion-41"
+      >
+        <label
+          class="emotion-42"
+        >
+          <input
+            checked=""
+            class="emotion-43"
+            name="contrast-algorithm"
+            type="radio"
+            value="wcag2"
+          />
+          WCAG 2.x
+        </label>
+        <label
+          class="emotion-42"
+        >
+          <input
+            class="emotion-43"
+            name="contrast-algorithm"
+            type="radio"
+            value="apca"
+          />
+          APCA
+        </label>
+      </div>
+    </fieldset>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -19,12 +19,83 @@ exports[`ColorInputs > renders without crashing 1`] = `
 }
 
 .emotion-1 {
+  border: 0;
+  color: inherit;
+  margin: 0;
+  min-width: 0;
+  padding: 1rem;
+  text-align: start;
+  width: 100%;
+}
+
+.emotion-2 {
+  display: block;
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+}
+
+.emotion-4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1.2rem;
+  line-height: 1.4;
+  position: relative;
+  -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+  transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+}
+
+.emotion-4:has(input:checked) {
+  font-weight: 700;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.3em;
+}
+
+.emotion-4:has(input:focus-visible) {
+  outline: currentColor dashed 2px;
+  outline-offset: 3px;
+}
+
+.emotion-5 {
+  cursor: pointer;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.emotion-8 {
   padding: 1rem;
   width: 100%;
 }
 
 @media (min-width: 768px) {
-  .emotion-1 {
+  .emotion-8 {
     -webkit-flex: 1 1 auto;
     -ms-flex: 1 1 auto;
     flex: 1 1 auto;
@@ -32,14 +103,14 @@ exports[`ColorInputs > renders without crashing 1`] = `
   }
 }
 
-.emotion-2 {
+.emotion-9 {
   display: inline-block;
   font-size: 1.2rem;
   margin-bottom: 0.5rem;
   width: 100%;
 }
 
-.emotion-3 {
+.emotion-10 {
   background: rgba(255, 255, 255, 0.1);
   border: solid 1px;
   border-radius: 3px;
@@ -49,7 +120,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   width: 100%;
 }
 
-.emotion-4 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -61,17 +132,17 @@ exports[`ColorInputs > renders without crashing 1`] = `
 }
 
 @media (min-width: 1024px) {
-  .emotion-4 {
+  .emotion-11 {
     margin: 0 -0.5rem;
   }
 }
 
-.emotion-5 {
+.emotion-12 {
   width: 100%;
 }
 
 @media (min-width: 1024px) {
-  .emotion-5 {
+  .emotion-12 {
     -webkit-flex: 1 0 auto;
     -ms-flex: 1 0 auto;
     flex: 1 0 auto;
@@ -80,7 +151,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   }
 }
 
-.emotion-9 {
+.emotion-16 {
   -webkit-appearance: none;
   background: transparent;
   border-radius: 2px;
@@ -90,7 +161,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   width: 100%;
 }
 
-.emotion-9::-webkit-slider-runnable-track {
+.emotion-16::-webkit-slider-runnable-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -102,7 +173,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   border-radius: 5px;
 }
 
-.emotion-9::-webkit-slider-thumb {
+.emotion-16::-webkit-slider-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -114,11 +185,11 @@ exports[`ColorInputs > renders without crashing 1`] = `
   margin-top: -9px;
 }
 
-.emotion-9:focus::-webkit-slider-runnable-track {
+.emotion-16:focus::-webkit-slider-runnable-track {
   background: currentColor;
 }
 
-.emotion-9::-moz-range-track {
+.emotion-16::-moz-range-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -130,7 +201,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   border-radius: 5px;
 }
 
-.emotion-9::-moz-range-thumb {
+.emotion-16::-moz-range-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -140,7 +211,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   cursor: pointer;
 }
 
-.emotion-9::-ms-track {
+.emotion-16::-ms-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -152,21 +223,21 @@ exports[`ColorInputs > renders without crashing 1`] = `
   color: transparent;
 }
 
-.emotion-9::-ms-fill-lower {
+.emotion-16::-ms-fill-lower {
   box-shadow: 0 0 0 #fff,0 0 0 #fff;
   background: currentColor;
   border: 1px solid currentColor;
   border-radius: 5px * 2;
 }
 
-.emotion-9::-ms-fill-upper {
+.emotion-16::-ms-fill-upper {
   box-shadow: 0 0 0 #fff,0 0 0 #fff;
   background: currentColor;
   border: 1px solid currentColor;
   border-radius: 5px * 2;
 }
 
-.emotion-9::-ms-thumb {
+.emotion-16::-ms-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -176,11 +247,11 @@ exports[`ColorInputs > renders without crashing 1`] = `
   cursor: pointer;
 }
 
-.emotion-9:focus::-ms-fill-lower {
+.emotion-16:focus::-ms-fill-lower {
   background: currentColor;
 }
 
-.emotion-9:focus::-ms-fill-upper {
+.emotion-16:focus::-ms-fill-upper {
   background: currentColor;
 }
 
@@ -189,18 +260,54 @@ exports[`ColorInputs > renders without crashing 1`] = `
     data-testid="color-input-form"
     style="color: rgb(255, 255, 255);"
   >
-    <div
+    <fieldset
       class="emotion-1"
     >
-      <label
+      <legend
         class="emotion-2"
+      >
+        Algorithm
+      </legend>
+      <div
+        class="emotion-3"
+      >
+        <label
+          class="emotion-4"
+        >
+          <input
+            checked=""
+            class="emotion-5"
+            name="contrast-algorithm"
+            type="radio"
+            value="wcag2"
+          />
+          WCAG 2.x
+        </label>
+        <label
+          class="emotion-4"
+        >
+          <input
+            class="emotion-5"
+            name="contrast-algorithm"
+            type="radio"
+            value="apca"
+          />
+          APCA
+        </label>
+      </div>
+    </fieldset>
+    <div
+      class="emotion-8"
+    >
+      <label
+        class="emotion-9"
         for="textColor"
       >
         Text Color
       </label>
       <input
         autocomplete="off"
-        class="emotion-3"
+        class="emotion-10"
         data-testid="textColor"
         id="textColor"
         style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -208,27 +315,27 @@ exports[`ColorInputs > renders without crashing 1`] = `
         value="#fff"
       />
       <div
-        class="emotion-4"
+        class="emotion-11"
         data-testid="form-hsl-sliders"
       >
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="textColor-hsl-Hue"
             >
               Hue 0°
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="textColor-hsl-Hue"
               id="textColor-hsl-Hue"
               max="360"
@@ -239,23 +346,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="textColor-hsl-Saturation"
             >
               Saturation 0%
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="textColor-hsl-Saturation"
               id="textColor-hsl-Saturation"
               max="100"
@@ -266,23 +373,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="textColor-hsl-Lightness"
             >
               Lightness 100%
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="textColor-hsl-Lightness"
               id="textColor-hsl-Lightness"
               max="100"
@@ -295,17 +402,17 @@ exports[`ColorInputs > renders without crashing 1`] = `
       </div>
     </div>
     <div
-      class="emotion-1"
+      class="emotion-8"
     >
       <label
-        class="emotion-2"
+        class="emotion-9"
         for="background"
       >
         Background
       </label>
       <input
         autocomplete="off"
-        class="emotion-3"
+        class="emotion-10"
         data-testid="background"
         id="background"
         style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -313,27 +420,27 @@ exports[`ColorInputs > renders without crashing 1`] = `
         value="#000"
       />
       <div
-        class="emotion-4"
+        class="emotion-11"
         data-testid="form-hsl-sliders"
       >
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="background-hsl-Hue"
             >
               Hue 0°
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="background-hsl-Hue"
               id="background-hsl-Hue"
               max="360"
@@ -344,23 +451,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="background-hsl-Saturation"
             >
               Saturation 0%
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="background-hsl-Saturation"
               id="background-hsl-Saturation"
               max="100"
@@ -371,23 +478,23 @@ exports[`ColorInputs > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-5"
+          class="emotion-12"
         >
           <div
-            class="emotion-6"
+            class="emotion-13"
           >
             <label
-              class="emotion-2"
+              class="emotion-9"
               for="background-hsl-Lightness"
             >
               Lightness 0%
             </label>
           </div>
           <div
-            class="emotion-8"
+            class="emotion-15"
           >
             <input
-              class="emotion-9"
+              class="emotion-16"
               data-testid="background-hsl-Lightness"
               id="background-hsl-Lightness"
               max="100"
@@ -399,28 +506,6 @@ exports[`ColorInputs > renders without crashing 1`] = `
         </div>
       </div>
     </div>
-    <fieldset>
-      <legend>
-        Contrast algorithm
-      </legend>
-      <label>
-        <input
-          checked=""
-          name="contrast-algorithm"
-          type="radio"
-          value="wcag2"
-        />
-        WCAG 2.x
-      </label>
-      <label>
-        <input
-          name="contrast-algorithm"
-          type="radio"
-          value="apca"
-        />
-        APCA
-      </label>
-    </fieldset>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -197,7 +197,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
 .emotion-40 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.15rem;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/colorInputs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -199,7 +199,7 @@ exports[`ColorInputs > renders without crashing 1`] = `
   float: left;
   font-size: 1.2rem;
   line-height: 1;
-  margin: 0 0 5px;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/colorInputs/__tests__/index.spec.tsx
+++ b/src/components/colorInputs/__tests__/index.spec.tsx
@@ -56,6 +56,12 @@ describe("ColorInputs", (): void => {
     expect(handleBackgroundColorInputChange).toHaveBeenCalledWith("#ccc");
   });
 
+  it("should call the handleAlgorithmChange callback on algorithm change", (): void => {
+    const { getByRole } = render(<ColorInputs />);
+    fireEvent.click(getByRole("radio", { name: "APCA" }));
+    expect(handleAlgorithmChange).toHaveBeenCalledWith("apca");
+  });
+
   it("should call the handleTextColorInputChange callback on text color slider change", (): void => {
     const { getByTestId } = render(<ColorInputs />);
     fireEvent.change(getByTestId("textColor-hsl-Lightness"), { target: { value: 12 } });

--- a/src/components/colorInputs/__tests__/index.spec.tsx
+++ b/src/components/colorInputs/__tests__/index.spec.tsx
@@ -6,6 +6,7 @@ import * as HomeContext from "../../../context/home";
 describe("ColorInputs", (): void => {
   let colorCombos: Array<ColorCombo> | false;
   let mockContext: HomeContext.HomeContextInterface;
+  let handleAlgorithmChange: HomeContext.HomeContextInterface["handleAlgorithmChange"];
   let handleBackgroundColorInputChange: (value: string) => void;
   let handleTextColorInputChange: (value: string) => void;
 
@@ -14,6 +15,7 @@ describe("ColorInputs", (): void => {
   );
 
   beforeAll((): void => {
+    handleAlgorithmChange = vi.fn();
     handleBackgroundColorInputChange = vi.fn<(value: string) => void>();
     handleTextColorInputChange = vi.fn<(value: string) => void>();
   });
@@ -23,9 +25,11 @@ describe("ColorInputs", (): void => {
     colorCombos = ColorCombos(["#fff", "#000"]);
     if (colorCombos !== false) {
       mockContext = {
+        handleAlgorithmChange,
         handleBackgroundColorInputChange,
         handleTextColorInputChange,
         siteData: {
+          algorithm: "wcag2",
           background: "#000",
           colorCombos,
           isLight: false,

--- a/src/components/colorInputs/index.tsx
+++ b/src/components/colorInputs/index.tsx
@@ -28,6 +28,7 @@ const ColorInputs: React.FC = (): ReactElement => {
 
   return (
     <Form dataTest="color-input-form" style={styles.form}>
+      <ContrastAlgorithmToggle algorithm={algorithm} onChange={handleAlgorithmChange} />
       <FormControl>
         <FormLabel htmlFor="textColor">Text Color</FormLabel>
         <FormInput
@@ -56,7 +57,6 @@ const ColorInputs: React.FC = (): ReactElement => {
           value={colorCombos[1].hex}
         />
       </FormControl>
-      <ContrastAlgorithmToggle algorithm={algorithm} onChange={handleAlgorithmChange} />
     </Form>
   );
 };

--- a/src/components/colorInputs/index.tsx
+++ b/src/components/colorInputs/index.tsx
@@ -28,7 +28,6 @@ const ColorInputs: React.FC = (): ReactElement => {
 
   return (
     <Form dataTest="color-input-form" style={styles.form}>
-      <ContrastAlgorithmToggle algorithm={algorithm} onChange={handleAlgorithmChange} />
       <FormControl>
         <FormLabel htmlFor="textColor">Text Color</FormLabel>
         <FormInput
@@ -57,6 +56,11 @@ const ColorInputs: React.FC = (): ReactElement => {
           value={colorCombos[1].hex}
         />
       </FormControl>
+      <ContrastAlgorithmToggle
+        algorithm={algorithm}
+        align="center"
+        onChange={handleAlgorithmChange}
+      />
     </Form>
   );
 };

--- a/src/components/colorInputs/index.tsx
+++ b/src/components/colorInputs/index.tsx
@@ -5,12 +5,14 @@ import { FormInput } from "../form-input";
 import { FormLabel } from "../form-label";
 import { HslSliders } from "../hsl-sliders";
 import { useSiteData } from "../../context/home";
+import { ContrastAlgorithmToggle } from "../contrast-algorithm-toggle";
 
 const ColorInputs: React.FC = (): ReactElement => {
   const {
+    handleAlgorithmChange,
     handleBackgroundColorInputChange,
     handleTextColorInputChange,
-    siteData: { background, colorCombos, isLight, textColor },
+    siteData: { algorithm, background, colorCombos, isLight, textColor },
   } = useSiteData();
 
   const formTextColor = isLight ? "#343334" : "#fff";
@@ -54,6 +56,7 @@ const ColorInputs: React.FC = (): ReactElement => {
           value={colorCombos[1].hex}
         />
       </FormControl>
+      <ContrastAlgorithmToggle algorithm={algorithm} onChange={handleAlgorithmChange} />
     </Form>
   );
 };

--- a/src/components/contrast-algorithm-toggle/__tests__/index.spec.tsx
+++ b/src/components/contrast-algorithm-toggle/__tests__/index.spec.tsx
@@ -2,6 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { ContrastAlgorithmToggle } from "..";
 
 describe("ContrastAlgorithmToggle", (): void => {
+  it("labels the control Algorithm", (): void => {
+    render(<ContrastAlgorithmToggle algorithm="wcag2" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("group", { name: "Algorithm" })).toBeTruthy();
+  });
+
   it("selects WCAG 2.x", (): void => {
     const onChange = vi.fn();
     render(<ContrastAlgorithmToggle algorithm="apca" onChange={onChange} />);

--- a/src/components/contrast-algorithm-toggle/__tests__/index.spec.tsx
+++ b/src/components/contrast-algorithm-toggle/__tests__/index.spec.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ContrastAlgorithmToggle } from "..";
+
+describe("ContrastAlgorithmToggle", (): void => {
+  it("selects WCAG 2.x", (): void => {
+    const onChange = vi.fn();
+    render(<ContrastAlgorithmToggle algorithm="apca" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "WCAG 2.x" }));
+
+    expect(onChange).toHaveBeenCalledWith("wcag2");
+  });
+
+  it("selects APCA", (): void => {
+    const onChange = vi.fn();
+    render(<ContrastAlgorithmToggle algorithm="wcag2" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "APCA" }));
+
+    expect(onChange).toHaveBeenCalledWith("apca");
+  });
+});

--- a/src/components/contrast-algorithm-toggle/index.tsx
+++ b/src/components/contrast-algorithm-toggle/index.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from "react";
+import type { ContrastAlgorithm } from "../../types";
+
+export interface ContrastAlgorithmToggleProps {
+  algorithm: ContrastAlgorithm;
+  onChange: (algorithm: ContrastAlgorithm) => void;
+}
+
+const ContrastAlgorithmToggle = ({
+  algorithm,
+  onChange,
+}: ContrastAlgorithmToggleProps): ReactElement => (
+  <fieldset>
+    <legend>Contrast algorithm</legend>
+    <label>
+      <input
+        checked={algorithm === "wcag2"}
+        name="contrast-algorithm"
+        onChange={() => onChange("wcag2")}
+        type="radio"
+        value="wcag2"
+      />
+      WCAG 2.x
+    </label>
+    <label>
+      <input
+        checked={algorithm === "apca"}
+        name="contrast-algorithm"
+        onChange={() => onChange("apca")}
+        type="radio"
+        value="apca"
+      />
+      APCA
+    </label>
+  </fieldset>
+);
+
+export { ContrastAlgorithmToggle };

--- a/src/components/contrast-algorithm-toggle/index.tsx
+++ b/src/components/contrast-algorithm-toggle/index.tsx
@@ -1,38 +1,43 @@
 import type { ReactElement } from "react";
 import type { ContrastAlgorithm } from "../../types";
+import { StyledFieldset, StyledLegend, StyledOption, StyledOptions, StyledRadio } from "./styled";
 
 export interface ContrastAlgorithmToggleProps {
   algorithm: ContrastAlgorithm;
+  align?: "start" | "center";
   onChange: (algorithm: ContrastAlgorithm) => void;
 }
 
 const ContrastAlgorithmToggle = ({
   algorithm,
+  align = "start",
   onChange,
 }: ContrastAlgorithmToggleProps): ReactElement => (
-  <fieldset>
-    <legend>Contrast algorithm</legend>
-    <label>
-      <input
-        checked={algorithm === "wcag2"}
-        name="contrast-algorithm"
-        onChange={() => onChange("wcag2")}
-        type="radio"
-        value="wcag2"
-      />
-      WCAG 2.x
-    </label>
-    <label>
-      <input
-        checked={algorithm === "apca"}
-        name="contrast-algorithm"
-        onChange={() => onChange("apca")}
-        type="radio"
-        value="apca"
-      />
-      APCA
-    </label>
-  </fieldset>
+  <StyledFieldset align={align}>
+    <StyledLegend>Algorithm</StyledLegend>
+    <StyledOptions align={align}>
+      <StyledOption>
+        <StyledRadio
+          checked={algorithm === "wcag2"}
+          name="contrast-algorithm"
+          onChange={() => onChange("wcag2")}
+          type="radio"
+          value="wcag2"
+        />
+        WCAG 2.x
+      </StyledOption>
+      <StyledOption>
+        <StyledRadio
+          checked={algorithm === "apca"}
+          name="contrast-algorithm"
+          onChange={() => onChange("apca")}
+          type="radio"
+          value="apca"
+        />
+        APCA
+      </StyledOption>
+    </StyledOptions>
+  </StyledFieldset>
 );
 
 export { ContrastAlgorithmToggle };

--- a/src/components/contrast-algorithm-toggle/styled.ts
+++ b/src/components/contrast-algorithm-toggle/styled.ts
@@ -17,8 +17,8 @@ export const StyledLegend = styled.legend`
   float: left;
   font-size: 1.2rem;
   line-height: 1;
-  /* 5px + line-height:1 ≈ 10px clear blue under most letters (g descender sits closer) */
-  margin: 0 0 5px;
+  /* With line-height:1 + floated legend, this margin is the real gap (~10px incl. g) */
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 `;

--- a/src/components/contrast-algorithm-toggle/styled.ts
+++ b/src/components/contrast-algorithm-toggle/styled.ts
@@ -13,7 +13,7 @@ export const StyledFieldset = styled.fieldset<{ align: "start" | "center" }>`
 export const StyledLegend = styled.legend`
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.15rem;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 `;

--- a/src/components/contrast-algorithm-toggle/styled.ts
+++ b/src/components/contrast-algorithm-toggle/styled.ts
@@ -13,7 +13,7 @@ export const StyledFieldset = styled.fieldset<{ align: "start" | "center" }>`
 export const StyledLegend = styled.legend`
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.15rem;
   padding: 0;
   width: 100%;
 `;

--- a/src/components/contrast-algorithm-toggle/styled.ts
+++ b/src/components/contrast-algorithm-toggle/styled.ts
@@ -1,0 +1,60 @@
+import styled from "@emotion/styled";
+
+export const StyledFieldset = styled.fieldset<{ align: "start" | "center" }>`
+  border: 0;
+  color: inherit;
+  margin: 0;
+  min-width: 0;
+  padding: 1rem;
+  text-align: ${(props): string => (props.align === "center" ? "center" : "start")};
+  width: 100%;
+`;
+
+export const StyledLegend = styled.legend`
+  display: block;
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  width: 100%;
+`;
+
+export const StyledOptions = styled.div<{ align: "start" | "center" }>`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  justify-content: ${(props): string => (props.align === "center" ? "center" : "flex-start")};
+`;
+
+export const StyledOption = styled.label`
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 1.2rem;
+  line-height: 1.4;
+  position: relative;
+  transition:
+    font-weight 150ms ease-out,
+    text-decoration-color 150ms ease-out;
+
+  &:has(input:checked) {
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.3em;
+  }
+
+  &:has(input:focus-visible) {
+    outline: currentColor dashed 2px;
+    outline-offset: 3px;
+  }
+`;
+
+export const StyledRadio = styled.input`
+  cursor: pointer;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;

--- a/src/components/contrast-algorithm-toggle/styled.ts
+++ b/src/components/contrast-algorithm-toggle/styled.ts
@@ -5,20 +5,26 @@ export const StyledFieldset = styled.fieldset<{ align: "start" | "center" }>`
   color: inherit;
   margin: 0;
   min-width: 0;
-  padding: 1rem;
+  /* Browsers put fieldset padding-top *between* legend and content — keep it 0 */
+  padding: 0 1rem 1rem;
   text-align: ${(props): string => (props.align === "center" ? "center" : "start")};
   width: 100%;
 `;
 
 export const StyledLegend = styled.legend`
+  /* float+width makes legend a real block so margin-bottom isn't eaten by legend layout quirks */
   display: block;
+  float: left;
   font-size: 1.2rem;
-  margin: 0 0 10px;
+  line-height: 1;
+  /* 5px + line-height:1 ≈ 10px clear blue under most letters (g descender sits closer) */
+  margin: 0 0 5px;
   padding: 0;
   width: 100%;
 `;
 
 export const StyledOptions = styled.div<{ align: "start" | "center" }>`
+  clear: both;
   display: flex;
   flex-wrap: wrap;
   gap: 1.25rem;
@@ -29,7 +35,9 @@ export const StyledOption = styled.label`
   cursor: pointer;
   display: inline-flex;
   font-size: 1.2rem;
-  line-height: 1.4;
+  line-height: 1;
+  /* room for underline without inventing gap above the glyphs */
+  padding-bottom: 0.35em;
   position: relative;
   transition:
     font-weight 150ms ease-out,
@@ -39,7 +47,7 @@ export const StyledOption = styled.label`
     font-weight: 700;
     text-decoration: underline;
     text-decoration-thickness: 2px;
-    text-underline-offset: 0.3em;
+    text-underline-offset: 0.2em;
   }
 
   &:has(input:focus-visible) {

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -150,12 +150,83 @@ exports[`Home > renders without crashing 1`] = `
 }
 
 .emotion-18 {
+  border: 0;
+  color: inherit;
+  margin: 0;
+  min-width: 0;
+  padding: 1rem;
+  text-align: start;
+  width: 100%;
+}
+
+.emotion-19 {
+  display: block;
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  width: 100%;
+}
+
+.emotion-20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+}
+
+.emotion-21 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1.2rem;
+  line-height: 1.4;
+  position: relative;
+  -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+  transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+}
+
+.emotion-21:has(input:checked) {
+  font-weight: 700;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.3em;
+}
+
+.emotion-21:has(input:focus-visible) {
+  outline: currentColor dashed 2px;
+  outline-offset: 3px;
+}
+
+.emotion-22 {
+  cursor: pointer;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.emotion-25 {
   padding: 1rem;
   width: 100%;
 }
 
 @media (min-width: 768px) {
-  .emotion-18 {
+  .emotion-25 {
     -webkit-flex: 1 1 auto;
     -ms-flex: 1 1 auto;
     flex: 1 1 auto;
@@ -163,14 +234,14 @@ exports[`Home > renders without crashing 1`] = `
   }
 }
 
-.emotion-19 {
+.emotion-26 {
   display: inline-block;
   font-size: 1.2rem;
   margin-bottom: 0.5rem;
   width: 100%;
 }
 
-.emotion-20 {
+.emotion-27 {
   background: rgba(255, 255, 255, 0.1);
   border: solid 1px;
   border-radius: 3px;
@@ -180,7 +251,7 @@ exports[`Home > renders without crashing 1`] = `
   width: 100%;
 }
 
-.emotion-21 {
+.emotion-28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,17 +263,17 @@ exports[`Home > renders without crashing 1`] = `
 }
 
 @media (min-width: 1024px) {
-  .emotion-21 {
+  .emotion-28 {
     margin: 0 -0.5rem;
   }
 }
 
-.emotion-22 {
+.emotion-29 {
   width: 100%;
 }
 
 @media (min-width: 1024px) {
-  .emotion-22 {
+  .emotion-29 {
     -webkit-flex: 1 0 auto;
     -ms-flex: 1 0 auto;
     flex: 1 0 auto;
@@ -211,7 +282,7 @@ exports[`Home > renders without crashing 1`] = `
   }
 }
 
-.emotion-26 {
+.emotion-33 {
   -webkit-appearance: none;
   background: transparent;
   border-radius: 2px;
@@ -221,7 +292,7 @@ exports[`Home > renders without crashing 1`] = `
   width: 100%;
 }
 
-.emotion-26::-webkit-slider-runnable-track {
+.emotion-33::-webkit-slider-runnable-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -233,7 +304,7 @@ exports[`Home > renders without crashing 1`] = `
   border-radius: 5px;
 }
 
-.emotion-26::-webkit-slider-thumb {
+.emotion-33::-webkit-slider-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -245,11 +316,11 @@ exports[`Home > renders without crashing 1`] = `
   margin-top: -9px;
 }
 
-.emotion-26:focus::-webkit-slider-runnable-track {
+.emotion-33:focus::-webkit-slider-runnable-track {
   background: currentColor;
 }
 
-.emotion-26::-moz-range-track {
+.emotion-33::-moz-range-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -261,7 +332,7 @@ exports[`Home > renders without crashing 1`] = `
   border-radius: 5px;
 }
 
-.emotion-26::-moz-range-thumb {
+.emotion-33::-moz-range-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -271,7 +342,7 @@ exports[`Home > renders without crashing 1`] = `
   cursor: pointer;
 }
 
-.emotion-26::-ms-track {
+.emotion-33::-ms-track {
   width: 100%;
   height: 4px;
   cursor: pointer;
@@ -283,21 +354,21 @@ exports[`Home > renders without crashing 1`] = `
   color: transparent;
 }
 
-.emotion-26::-ms-fill-lower {
+.emotion-33::-ms-fill-lower {
   box-shadow: 0 0 0 #fff,0 0 0 #fff;
   background: currentColor;
   border: 1px solid currentColor;
   border-radius: 5px * 2;
 }
 
-.emotion-26::-ms-fill-upper {
+.emotion-33::-ms-fill-upper {
   box-shadow: 0 0 0 #fff,0 0 0 #fff;
   background: currentColor;
   border: 1px solid currentColor;
   border-radius: 5px * 2;
 }
 
-.emotion-26::-ms-thumb {
+.emotion-33::-ms-thumb {
   box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
   border: 1px solid currentColor;
   height: 20px;
@@ -307,11 +378,11 @@ exports[`Home > renders without crashing 1`] = `
   cursor: pointer;
 }
 
-.emotion-26:focus::-ms-fill-lower {
+.emotion-33:focus::-ms-fill-lower {
   background: currentColor;
 }
 
-.emotion-26:focus::-ms-fill-upper {
+.emotion-33:focus::-ms-fill-upper {
   background: currentColor;
 }
 
@@ -409,18 +480,54 @@ exports[`Home > renders without crashing 1`] = `
         data-testid="color-input-form"
         style="color: rgb(255, 255, 255);"
       >
-        <div
+        <fieldset
           class="emotion-18"
         >
-          <label
+          <legend
             class="emotion-19"
+          >
+            Algorithm
+          </legend>
+          <div
+            class="emotion-20"
+          >
+            <label
+              class="emotion-21"
+            >
+              <input
+                checked=""
+                class="emotion-22"
+                name="contrast-algorithm"
+                type="radio"
+                value="wcag2"
+              />
+              WCAG 2.x
+            </label>
+            <label
+              class="emotion-21"
+            >
+              <input
+                class="emotion-22"
+                name="contrast-algorithm"
+                type="radio"
+                value="apca"
+              />
+              APCA
+            </label>
+          </div>
+        </fieldset>
+        <div
+          class="emotion-25"
+        >
+          <label
+            class="emotion-26"
             for="textColor"
           >
             Text Color
           </label>
           <input
             autocomplete="off"
-            class="emotion-20"
+            class="emotion-27"
             data-testid="textColor"
             id="textColor"
             style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -428,27 +535,27 @@ exports[`Home > renders without crashing 1`] = `
             value="#fff"
           />
           <div
-            class="emotion-21"
+            class="emotion-28"
             data-testid="form-hsl-sliders"
           >
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="textColor-hsl-Hue"
                 >
                   Hue 0°
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="textColor-hsl-Hue"
                   id="textColor-hsl-Hue"
                   max="360"
@@ -459,23 +566,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="textColor-hsl-Saturation"
                 >
                   Saturation 0%
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="textColor-hsl-Saturation"
                   id="textColor-hsl-Saturation"
                   max="100"
@@ -486,23 +593,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="textColor-hsl-Lightness"
                 >
                   Lightness 100%
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="textColor-hsl-Lightness"
                   id="textColor-hsl-Lightness"
                   max="100"
@@ -515,17 +622,17 @@ exports[`Home > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-18"
+          class="emotion-25"
         >
           <label
-            class="emotion-19"
+            class="emotion-26"
             for="background"
           >
             Background
           </label>
           <input
             autocomplete="off"
-            class="emotion-20"
+            class="emotion-27"
             data-testid="background"
             id="background"
             style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -533,27 +640,27 @@ exports[`Home > renders without crashing 1`] = `
             value="#000"
           />
           <div
-            class="emotion-21"
+            class="emotion-28"
             data-testid="form-hsl-sliders"
           >
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="background-hsl-Hue"
                 >
                   Hue 0°
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="background-hsl-Hue"
                   id="background-hsl-Hue"
                   max="360"
@@ -564,23 +671,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="background-hsl-Saturation"
                 >
                   Saturation 0%
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="background-hsl-Saturation"
                   id="background-hsl-Saturation"
                   max="100"
@@ -591,23 +698,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-22"
+              class="emotion-29"
             >
               <div
-                class="emotion-23"
+                class="emotion-30"
               >
                 <label
-                  class="emotion-19"
+                  class="emotion-26"
                   for="background-hsl-Lightness"
                 >
                   Lightness 0%
                 </label>
               </div>
               <div
-                class="emotion-25"
+                class="emotion-32"
               >
                 <input
-                  class="emotion-26"
+                  class="emotion-33"
                   data-testid="background-hsl-Lightness"
                   id="background-hsl-Lightness"
                   max="100"
@@ -619,28 +726,6 @@ exports[`Home > renders without crashing 1`] = `
             </div>
           </div>
         </div>
-        <fieldset>
-          <legend>
-            Contrast algorithm
-          </legend>
-          <label>
-            <input
-              checked=""
-              name="contrast-algorithm"
-              type="radio"
-              value="wcag2"
-            />
-            WCAG 2.x
-          </label>
-          <label>
-            <input
-              name="contrast-algorithm"
-              type="radio"
-              value="apca"
-            />
-            APCA
-          </label>
-        </fieldset>
       </div>
     </div>
   </main>

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -150,24 +150,190 @@ exports[`Home > renders without crashing 1`] = `
 }
 
 .emotion-18 {
+  padding: 1rem;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .emotion-18 {
+    -webkit-flex: 1 1 auto;
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+    width: 50%;
+  }
+}
+
+.emotion-19 {
+  display: inline-block;
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.emotion-20 {
+  background: rgba(255, 255, 255, 0.1);
+  border: solid 1px;
+  border-radius: 3px;
+  font-size: 1.2rem;
+  padding: 0.5rem 1rem;
+  margin-bottom: 2rem;
+  width: 100%;
+}
+
+.emotion-21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 1024px) {
+  .emotion-21 {
+    margin: 0 -0.5rem;
+  }
+}
+
+.emotion-22 {
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .emotion-22 {
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+    padding: 0 0.5rem;
+    width: 33.3333%;
+  }
+}
+
+.emotion-26 {
+  -webkit-appearance: none;
+  background: transparent;
+  border-radius: 2px;
+  color: currentColor;
+  display: block;
+  margin: 10px 0;
+  width: 100%;
+}
+
+.emotion-26::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px;
+}
+
+.emotion-26::-webkit-slider-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-top: -9px;
+}
+
+.emotion-26:focus::-webkit-slider-runnable-track {
+  background: currentColor;
+}
+
+.emotion-26::-moz-range-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px;
+}
+
+.emotion-26::-moz-range-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+}
+
+.emotion-26::-ms-track {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  background: transparent;
+  border-color: transparent;
+  border-width: 8px 0;
+  color: transparent;
+}
+
+.emotion-26::-ms-fill-lower {
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px * 2;
+}
+
+.emotion-26::-ms-fill-upper {
+  box-shadow: 0 0 0 #fff,0 0 0 #fff;
+  background: currentColor;
+  border: 1px solid currentColor;
+  border-radius: 5px * 2;
+}
+
+.emotion-26::-ms-thumb {
+  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
+  border: 1px solid currentColor;
+  height: 20px;
+  width: 8px;
+  border-radius: 2px;
+  background: currentColor;
+  cursor: pointer;
+}
+
+.emotion-26:focus::-ms-fill-lower {
+  background: currentColor;
+}
+
+.emotion-26:focus::-ms-fill-upper {
+  background: currentColor;
+}
+
+.emotion-56 {
   border: 0;
   color: inherit;
   margin: 0;
   min-width: 0;
   padding: 1rem;
-  text-align: start;
+  text-align: center;
   width: 100%;
 }
 
-.emotion-19 {
+.emotion-57 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.15rem;
   padding: 0;
   width: 100%;
 }
 
-.emotion-20 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -177,13 +343,13 @@ exports[`Home > renders without crashing 1`] = `
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   gap: 1.25rem;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
-.emotion-21 {
+.emotion-59 {
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -196,7 +362,7 @@ exports[`Home > renders without crashing 1`] = `
   transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
 }
 
-.emotion-21:has(input:checked) {
+.emotion-59:has(input:checked) {
   font-weight: 700;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -204,12 +370,12 @@ exports[`Home > renders without crashing 1`] = `
   text-underline-offset: 0.3em;
 }
 
-.emotion-21:has(input:focus-visible) {
+.emotion-59:has(input:focus-visible) {
   outline: currentColor dashed 2px;
   outline-offset: 3px;
 }
 
-.emotion-22 {
+.emotion-60 {
   cursor: pointer;
   height: 100%;
   left: 0;
@@ -218,172 +384,6 @@ exports[`Home > renders without crashing 1`] = `
   position: absolute;
   top: 0;
   width: 100%;
-}
-
-.emotion-25 {
-  padding: 1rem;
-  width: 100%;
-}
-
-@media (min-width: 768px) {
-  .emotion-25 {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
-    width: 50%;
-  }
-}
-
-.emotion-26 {
-  display: inline-block;
-  font-size: 1.2rem;
-  margin-bottom: 0.5rem;
-  width: 100%;
-}
-
-.emotion-27 {
-  background: rgba(255, 255, 255, 0.1);
-  border: solid 1px;
-  border-radius: 3px;
-  font-size: 1.2rem;
-  padding: 0.5rem 1rem;
-  margin-bottom: 2rem;
-  width: 100%;
-}
-
-.emotion-28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
-@media (min-width: 1024px) {
-  .emotion-28 {
-    margin: 0 -0.5rem;
-  }
-}
-
-.emotion-29 {
-  width: 100%;
-}
-
-@media (min-width: 1024px) {
-  .emotion-29 {
-    -webkit-flex: 1 0 auto;
-    -ms-flex: 1 0 auto;
-    flex: 1 0 auto;
-    padding: 0 0.5rem;
-    width: 33.3333%;
-  }
-}
-
-.emotion-33 {
-  -webkit-appearance: none;
-  background: transparent;
-  border-radius: 2px;
-  color: currentColor;
-  display: block;
-  margin: 10px 0;
-  width: 100%;
-}
-
-.emotion-33::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px;
-}
-
-.emotion-33::-webkit-slider-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-  -webkit-appearance: none;
-  margin-top: -9px;
-}
-
-.emotion-33:focus::-webkit-slider-runnable-track {
-  background: currentColor;
-}
-
-.emotion-33::-moz-range-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px;
-}
-
-.emotion-33::-moz-range-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-}
-
-.emotion-33::-ms-track {
-  width: 100%;
-  height: 4px;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  background: transparent;
-  border-color: transparent;
-  border-width: 8px 0;
-  color: transparent;
-}
-
-.emotion-33::-ms-fill-lower {
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px * 2;
-}
-
-.emotion-33::-ms-fill-upper {
-  box-shadow: 0 0 0 #fff,0 0 0 #fff;
-  background: currentColor;
-  border: 1px solid currentColor;
-  border-radius: 5px * 2;
-}
-
-.emotion-33::-ms-thumb {
-  box-shadow: 1px 1px 1px #999,0 0 1px #a6a6a6;
-  border: 1px solid currentColor;
-  height: 20px;
-  width: 8px;
-  border-radius: 2px;
-  background: currentColor;
-  cursor: pointer;
-}
-
-.emotion-33:focus::-ms-fill-lower {
-  background: currentColor;
-}
-
-.emotion-33:focus::-ms-fill-upper {
-  background: currentColor;
 }
 
 <main
@@ -480,54 +480,18 @@ exports[`Home > renders without crashing 1`] = `
         data-testid="color-input-form"
         style="color: rgb(255, 255, 255);"
       >
-        <fieldset
+        <div
           class="emotion-18"
         >
-          <legend
-            class="emotion-19"
-          >
-            Algorithm
-          </legend>
-          <div
-            class="emotion-20"
-          >
-            <label
-              class="emotion-21"
-            >
-              <input
-                checked=""
-                class="emotion-22"
-                name="contrast-algorithm"
-                type="radio"
-                value="wcag2"
-              />
-              WCAG 2.x
-            </label>
-            <label
-              class="emotion-21"
-            >
-              <input
-                class="emotion-22"
-                name="contrast-algorithm"
-                type="radio"
-                value="apca"
-              />
-              APCA
-            </label>
-          </div>
-        </fieldset>
-        <div
-          class="emotion-25"
-        >
           <label
-            class="emotion-26"
+            class="emotion-19"
             for="textColor"
           >
             Text Color
           </label>
           <input
             autocomplete="off"
-            class="emotion-27"
+            class="emotion-20"
             data-testid="textColor"
             id="textColor"
             style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -535,27 +499,27 @@ exports[`Home > renders without crashing 1`] = `
             value="#fff"
           />
           <div
-            class="emotion-28"
+            class="emotion-21"
             data-testid="form-hsl-sliders"
           >
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="textColor-hsl-Hue"
                 >
                   Hue 0°
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="textColor-hsl-Hue"
                   id="textColor-hsl-Hue"
                   max="360"
@@ -566,23 +530,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="textColor-hsl-Saturation"
                 >
                   Saturation 0%
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="textColor-hsl-Saturation"
                   id="textColor-hsl-Saturation"
                   max="100"
@@ -593,23 +557,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="textColor-hsl-Lightness"
                 >
                   Lightness 100%
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="textColor-hsl-Lightness"
                   id="textColor-hsl-Lightness"
                   max="100"
@@ -622,17 +586,17 @@ exports[`Home > renders without crashing 1`] = `
           </div>
         </div>
         <div
-          class="emotion-25"
+          class="emotion-18"
         >
           <label
-            class="emotion-26"
+            class="emotion-19"
             for="background"
           >
             Background
           </label>
           <input
             autocomplete="off"
-            class="emotion-27"
+            class="emotion-20"
             data-testid="background"
             id="background"
             style="border-color: rgb(255, 255, 255); color: inherit;"
@@ -640,27 +604,27 @@ exports[`Home > renders without crashing 1`] = `
             value="#000"
           />
           <div
-            class="emotion-28"
+            class="emotion-21"
             data-testid="form-hsl-sliders"
           >
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="background-hsl-Hue"
                 >
                   Hue 0°
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="background-hsl-Hue"
                   id="background-hsl-Hue"
                   max="360"
@@ -671,23 +635,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="background-hsl-Saturation"
                 >
                   Saturation 0%
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="background-hsl-Saturation"
                   id="background-hsl-Saturation"
                   max="100"
@@ -698,23 +662,23 @@ exports[`Home > renders without crashing 1`] = `
               </div>
             </div>
             <div
-              class="emotion-29"
+              class="emotion-22"
             >
               <div
-                class="emotion-30"
+                class="emotion-23"
               >
                 <label
-                  class="emotion-26"
+                  class="emotion-19"
                   for="background-hsl-Lightness"
                 >
                   Lightness 0%
                 </label>
               </div>
               <div
-                class="emotion-32"
+                class="emotion-25"
               >
                 <input
-                  class="emotion-33"
+                  class="emotion-26"
                   data-testid="background-hsl-Lightness"
                   id="background-hsl-Lightness"
                   max="100"
@@ -726,6 +690,42 @@ exports[`Home > renders without crashing 1`] = `
             </div>
           </div>
         </div>
+        <fieldset
+          class="emotion-56"
+        >
+          <legend
+            class="emotion-57"
+          >
+            Algorithm
+          </legend>
+          <div
+            class="emotion-58"
+          >
+            <label
+              class="emotion-59"
+            >
+              <input
+                checked=""
+                class="emotion-60"
+                name="contrast-algorithm"
+                type="radio"
+                value="wcag2"
+              />
+              WCAG 2.x
+            </label>
+            <label
+              class="emotion-59"
+            >
+              <input
+                class="emotion-60"
+                name="contrast-algorithm"
+                type="radio"
+                value="apca"
+              />
+              APCA
+            </label>
+          </div>
+        </fieldset>
       </div>
     </div>
   </main>

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -619,6 +619,28 @@ exports[`Home > renders without crashing 1`] = `
             </div>
           </div>
         </div>
+        <fieldset>
+          <legend>
+            Contrast algorithm
+          </legend>
+          <label>
+            <input
+              checked=""
+              name="contrast-algorithm"
+              type="radio"
+              value="wcag2"
+            />
+            WCAG 2.x
+          </label>
+          <label>
+            <input
+              name="contrast-algorithm"
+              type="radio"
+              value="apca"
+            />
+            APCA
+          </label>
+        </fieldset>
       </div>
     </div>
   </main>

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -330,7 +330,7 @@ exports[`Home > renders without crashing 1`] = `
   float: left;
   font-size: 1.2rem;
   line-height: 1;
-  margin: 0 0 5px;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -328,7 +328,7 @@ exports[`Home > renders without crashing 1`] = `
 .emotion-57 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.15rem;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/home/__tests__/__snapshots__/index.spec.tsx.snap
@@ -320,20 +320,23 @@ exports[`Home > renders without crashing 1`] = `
   color: inherit;
   margin: 0;
   min-width: 0;
-  padding: 1rem;
+  padding: 0 1rem 1rem;
   text-align: center;
   width: 100%;
 }
 
 .emotion-57 {
   display: block;
+  float: left;
   font-size: 1.2rem;
-  margin: 0 0 10px;
+  line-height: 1;
+  margin: 0 0 5px;
   padding: 0;
   width: 100%;
 }
 
 .emotion-58 {
+  clear: both;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -356,7 +359,8 @@ exports[`Home > renders without crashing 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1.2rem;
-  line-height: 1.4;
+  line-height: 1;
+  padding-bottom: 0.35em;
   position: relative;
   -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
   transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
@@ -367,7 +371,7 @@ exports[`Home > renders without crashing 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 2px;
-  text-underline-offset: 0.3em;
+  text-underline-offset: 0.2em;
 }
 
 .emotion-59:has(input:focus-visible) {

--- a/src/components/home/__tests__/index.spec.tsx
+++ b/src/components/home/__tests__/index.spec.tsx
@@ -1,10 +1,10 @@
-import { render } from "@testing-library/react";
 import { Home } from "..";
 import { SiteDataProvider } from "../../../context/home";
+import { renderWithRouter } from "../../../test/render-with-router";
 
 describe("Home", (): void => {
   it("renders without crashing", (): void => {
-    const { asFragment } = render(
+    const { asFragment } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -74,7 +74,7 @@ exports[`Palette Page > renders without crashing 1`] = `
 .emotion-2 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.15rem;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -66,20 +66,23 @@ exports[`Palette Page > renders without crashing 1`] = `
   color: inherit;
   margin: 0;
   min-width: 0;
-  padding: 1rem;
+  padding: 0 1rem 1rem;
   text-align: center;
   width: 100%;
 }
 
 .emotion-2 {
   display: block;
+  float: left;
   font-size: 1.2rem;
-  margin: 0 0 10px;
+  line-height: 1;
+  margin: 0 0 5px;
   padding: 0;
   width: 100%;
 }
 
 .emotion-3 {
+  clear: both;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -102,7 +105,8 @@ exports[`Palette Page > renders without crashing 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1.2rem;
-  line-height: 1.4;
+  line-height: 1;
+  padding-bottom: 0.35em;
   position: relative;
   -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
   transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
@@ -113,7 +117,7 @@ exports[`Palette Page > renders without crashing 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 2px;
-  text-underline-offset: 0.3em;
+  text-underline-offset: 0.2em;
 }
 
 .emotion-4:has(input:focus-visible) {

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -54,28 +54,124 @@ exports[`Palette Page > renders without crashing 1`] = `
       />
     </div>
   </form>
-  <fieldset>
-    <legend>
-      Contrast algorithm
-    </legend>
-    <label>
-      <input
-        checked=""
-        name="contrast-algorithm"
-        type="radio"
-        value="wcag2"
-      />
-      WCAG 2.x
-    </label>
-    <label>
-      <input
-        name="contrast-algorithm"
-        type="radio"
-        value="apca"
-      />
-      APCA
-    </label>
-  </fieldset>
+  .emotion-0 {
+  margin: 1.5rem auto 0.5rem;
+  max-width: 1200px;
+  padding: 0 1rem;
+  text-align: center;
+}
+
+.emotion-1 {
+  border: 0;
+  color: inherit;
+  margin: 0;
+  min-width: 0;
+  padding: 1rem;
+  text-align: center;
+  width: 100%;
+}
+
+.emotion-2 {
+  display: block;
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.emotion-4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1.2rem;
+  line-height: 1.4;
+  position: relative;
+  -webkit-transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+  transition: font-weight 150ms ease-out,text-decoration-color 150ms ease-out;
+}
+
+.emotion-4:has(input:checked) {
+  font-weight: 700;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.3em;
+}
+
+.emotion-4:has(input:focus-visible) {
+  outline: currentColor dashed 2px;
+  outline-offset: 3px;
+}
+
+.emotion-5 {
+  cursor: pointer;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+<div
+    class="emotion-0"
+  >
+    <fieldset
+      class="emotion-1"
+    >
+      <legend
+        class="emotion-2"
+      >
+        Algorithm
+      </legend>
+      <div
+        class="emotion-3"
+      >
+        <label
+          class="emotion-4"
+        >
+          <input
+            checked=""
+            class="emotion-5"
+            name="contrast-algorithm"
+            type="radio"
+            value="wcag2"
+          />
+          WCAG 2.x
+        </label>
+        <label
+          class="emotion-4"
+        >
+          <input
+            class="emotion-5"
+            name="contrast-algorithm"
+            type="radio"
+            value="apca"
+          />
+          APCA
+        </label>
+      </div>
+    </fieldset>
+  </div>
   .emotion-0 {
   margin-top: 3rem;
   overflow-x: auto;

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -74,7 +74,7 @@ exports[`Palette Page > renders without crashing 1`] = `
 .emotion-2 {
   display: block;
   font-size: 1.2rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.15rem;
   padding: 0;
   width: 100%;
 }

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -76,7 +76,7 @@ exports[`Palette Page > renders without crashing 1`] = `
   float: left;
   font-size: 1.2rem;
   line-height: 1;
-  margin: 0 0 5px;
+  margin: 0 0 10px;
   padding: 0;
   width: 100%;
 }

--- a/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
+++ b/src/components/palette-page/__tests__/__snapshots__/palette.spec.tsx.snap
@@ -54,6 +54,28 @@ exports[`Palette Page > renders without crashing 1`] = `
       />
     </div>
   </form>
+  <fieldset>
+    <legend>
+      Contrast algorithm
+    </legend>
+    <label>
+      <input
+        checked=""
+        name="contrast-algorithm"
+        type="radio"
+        value="wcag2"
+      />
+      WCAG 2.x
+    </label>
+    <label>
+      <input
+        name="contrast-algorithm"
+        type="radio"
+        value="apca"
+      />
+      APCA
+    </label>
+  </fieldset>
   .emotion-0 {
   margin-top: 3rem;
   overflow-x: auto;

--- a/src/components/palette-page/__tests__/palette.spec.tsx
+++ b/src/components/palette-page/__tests__/palette.spec.tsx
@@ -22,9 +22,6 @@ describe("Palette Page", (): void => {
 
     const apca = getByRole("radio", { name: "APCA" });
     fireEvent.click(apca);
-    expect(apca).toBeInstanceOf(HTMLInputElement);
-    if (apca instanceof HTMLInputElement) {
-      expect(apca.checked).toBe(true);
-    }
+    expect(getByRole("radio", { checked: true, name: "APCA" })).toBe(apca);
   });
 });

--- a/src/components/palette-page/__tests__/palette.spec.tsx
+++ b/src/components/palette-page/__tests__/palette.spec.tsx
@@ -1,10 +1,10 @@
-import { render } from "@testing-library/react";
 import { PaletteDataProvider } from "../../../context/palette";
+import { renderWithRouter } from "../../../test/render-with-router";
 import { PalettePage } from "..";
 
 describe("Palette Page", (): void => {
   it("renders without crashing", (): void => {
-    const { asFragment } = render(
+    const { asFragment } = renderWithRouter(
       <PaletteDataProvider>
         <PalettePage />
       </PaletteDataProvider>,

--- a/src/components/palette-page/__tests__/palette.spec.tsx
+++ b/src/components/palette-page/__tests__/palette.spec.tsx
@@ -11,4 +11,16 @@ describe("Palette Page", (): void => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it("selects the APCA algorithm", (): void => {
+    const { getByRole } = renderWithRouter(
+      <PaletteDataProvider>
+        <PalettePage />
+      </PaletteDataProvider>,
+    );
+
+    const apca = getByRole("radio", { name: "APCA" });
+    apca.click();
+    expect(apca).toBeChecked();
+  });
 });

--- a/src/components/palette-page/__tests__/palette.spec.tsx
+++ b/src/components/palette-page/__tests__/palette.spec.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import { PaletteDataProvider } from "../../../context/palette";
 import { renderWithRouter } from "../../../test/render-with-router";
 import { PalettePage } from "..";
@@ -20,7 +21,10 @@ describe("Palette Page", (): void => {
     );
 
     const apca = getByRole("radio", { name: "APCA" });
-    apca.click();
-    expect(apca).toBeChecked();
+    fireEvent.click(apca);
+    expect(apca).toBeInstanceOf(HTMLInputElement);
+    if (apca instanceof HTMLInputElement) {
+      expect(apca.checked).toBe(true);
+    }
   });
 });

--- a/src/components/palette-page/index.tsx
+++ b/src/components/palette-page/index.tsx
@@ -20,6 +20,7 @@ const PalettePage: React.FC = (): React.ReactElement => {
       />
       <ContrastAlgorithmToggle algorithm={paletteData.algorithm} onChange={handleAlgorithmChange} />
       <ColorMatrix
+        algorithm={paletteData.algorithm}
         colorCombos={paletteData.colorCombos}
         colors={paletteData.colors}
         onColorChange={handleColorChange}

--- a/src/components/palette-page/index.tsx
+++ b/src/components/palette-page/index.tsx
@@ -3,9 +3,11 @@ import * as React from "react";
 import { PaletteInput } from "../palette-input";
 import { ColorMatrix } from "../color-matrix";
 import { usePaletteData } from "../../context/palette";
+import { ContrastAlgorithmToggle } from "../contrast-algorithm-toggle";
 
 const PalettePage: React.FC = (): React.ReactElement => {
-  const { handleColorChange, handleNewColor, paletteData } = usePaletteData();
+  const { handleAlgorithmChange, handleColorChange, handleNewColor, paletteData } =
+    usePaletteData();
   return (
     <>
       <PaletteInput
@@ -16,6 +18,7 @@ const PalettePage: React.FC = (): React.ReactElement => {
         }
         onColorAdd={handleNewColor}
       />
+      <ContrastAlgorithmToggle algorithm={paletteData.algorithm} onChange={handleAlgorithmChange} />
       <ColorMatrix
         colorCombos={paletteData.colorCombos}
         colors={paletteData.colors}

--- a/src/components/palette-page/index.tsx
+++ b/src/components/palette-page/index.tsx
@@ -1,9 +1,17 @@
 import * as React from "react";
+import styled from "@emotion/styled";
 
 import { PaletteInput } from "../palette-input";
 import { ColorMatrix } from "../color-matrix";
 import { usePaletteData } from "../../context/palette";
 import { ContrastAlgorithmToggle } from "../contrast-algorithm-toggle";
+
+const StyledAlgorithmRow = styled.div`
+  margin: 1.5rem auto 0.5rem;
+  max-width: 1200px;
+  padding: 0 1rem;
+  text-align: center;
+`;
 
 const PalettePage: React.FC = (): React.ReactElement => {
   const { handleAlgorithmChange, handleColorChange, handleNewColor, paletteData } =
@@ -18,7 +26,13 @@ const PalettePage: React.FC = (): React.ReactElement => {
         }
         onColorAdd={handleNewColor}
       />
-      <ContrastAlgorithmToggle algorithm={paletteData.algorithm} onChange={handleAlgorithmChange} />
+      <StyledAlgorithmRow>
+        <ContrastAlgorithmToggle
+          algorithm={paletteData.algorithm}
+          align="center"
+          onChange={handleAlgorithmChange}
+        />
+      </StyledAlgorithmRow>
       <ColorMatrix
         algorithm={paletteData.algorithm}
         colorCombos={paletteData.colorCombos}

--- a/src/components/results/__tests__/index.spec.tsx
+++ b/src/components/results/__tests__/index.spec.tsx
@@ -1,5 +1,7 @@
 import { SiteDataProvider } from "../../../context/home";
 import { renderWithRouter } from "../../../test/render-with-router";
+import { vi } from "vitest";
+import * as contrastResults from "../../../utils/contrast-results";
 import { Results } from "..";
 
 describe("Results", (): void => {
@@ -144,5 +146,90 @@ describe("Results", (): void => {
 
     expect(getByText("APCA Lc")).not.toBeNull();
     expect(queryByText("AA: 4.5 AAA: 7.0")).toBeNull();
+  });
+
+  it("renders an APCA Yup with readability rows", (): void => {
+    const { getByTestId, getByText } = renderWithRouter(
+      <SiteDataProvider
+        initialSiteData={{
+          algorithm: "apca",
+          background: "#000",
+          colorCombos: [],
+          isLight: true,
+          textColor: "#fff",
+        }}
+      >
+        <Results />
+      </SiteDataProvider>,
+    );
+
+    expect(getByTestId("contrastResults-heading").textContent).toBe("Yup");
+    expect(getByText(/Body Text/)).not.toBeNull();
+    expect(getByText(/Content Text/)).not.toBeNull();
+    expect(getByText(/Large Text/)).not.toBeNull();
+  });
+
+  it("renders an APCA Kinda when Content passes but Body fails", (): void => {
+    const { getByTestId } = renderWithRouter(
+      <SiteDataProvider
+        initialSiteData={{
+          algorithm: "apca",
+          background: "#888888",
+          colorCombos: [],
+          isLight: true,
+          textColor: "#ffffff",
+        }}
+      >
+        <Results />
+      </SiteDataProvider>,
+    );
+
+    expect(getByTestId("contrastResults-heading").textContent).toBe("Kinda");
+  });
+
+  it("renders Seriously? for very low APCA contrast", (): void => {
+    const { getByTestId } = renderWithRouter(
+      <SiteDataProvider
+        initialSiteData={{
+          algorithm: "apca",
+          background: "#fff",
+          colorCombos: [],
+          isLight: true,
+          textColor: "#fff",
+        }}
+      >
+        <Results />
+      </SiteDataProvider>,
+    );
+
+    expect(getByTestId("contrastResults-heading").textContent).toBe("Nope");
+    expect(getByTestId("contrastResults-seriously")).not.toBeNull();
+  });
+
+  it("renders Unavailable when APCA data is missing", (): void => {
+    const spy = vi.spyOn(contrastResults, "getContrastDisplayResult").mockReturnValue({
+      heading: "Unavailable",
+      metricLabel: "APCA Lc",
+      metricValue: "Unavailable",
+      rows: [],
+      showSeriously: false,
+    });
+
+    const { getByTestId } = renderWithRouter(
+      <SiteDataProvider
+        initialSiteData={{
+          algorithm: "apca",
+          background: "#000",
+          colorCombos: [],
+          isLight: true,
+          textColor: "#fff",
+        }}
+      >
+        <Results />
+      </SiteDataProvider>,
+    );
+
+    expect(getByTestId("contrastResults-heading").textContent).toBe("Unavailable");
+    spy.mockRestore();
   });
 });

--- a/src/components/results/__tests__/index.spec.tsx
+++ b/src/components/results/__tests__/index.spec.tsx
@@ -1,10 +1,10 @@
-import { render } from "@testing-library/react";
 import { SiteDataProvider } from "../../../context/home";
+import { renderWithRouter } from "../../../test/render-with-router";
 import { Results } from "..";
 
 describe("Results", (): void => {
   it("renders without crashing", (): void => {
-    const { asFragment } = render(
+    const { asFragment } = renderWithRouter(
       <SiteDataProvider>
         <Results />
       </SiteDataProvider>,
@@ -13,7 +13,7 @@ describe("Results", (): void => {
   });
 
   it("should render a triple a result correctly", (): void => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",
@@ -32,7 +32,7 @@ describe("Results", (): void => {
   });
 
   it("should render a large text triple a result correctly", (): void => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#666",
@@ -51,7 +51,7 @@ describe("Results", (): void => {
   });
 
   it("should render a large text double a result correctly", (): void => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",
@@ -70,7 +70,7 @@ describe("Results", (): void => {
   });
 
   it("should render a nope a result correctly", (): void => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",
@@ -89,7 +89,7 @@ describe("Results", (): void => {
   });
 
   it("should render a seriously? a result correctly", (): void => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",
@@ -106,7 +106,7 @@ describe("Results", (): void => {
   });
 
   it("should set the font color of seriously? to #343334 on light backgrounds", (): void => {
-    const { asFragment } = render(
+    const { asFragment } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
           background: "#000",

--- a/src/components/results/__tests__/index.spec.tsx
+++ b/src/components/results/__tests__/index.spec.tsx
@@ -16,6 +16,7 @@ describe("Results", (): void => {
     const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#000",
           colorCombos: [],
           isLight: true,
@@ -35,6 +36,7 @@ describe("Results", (): void => {
     const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#666",
           colorCombos: [],
           isLight: true,
@@ -54,6 +56,7 @@ describe("Results", (): void => {
     const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#000",
           colorCombos: [],
           isLight: true,
@@ -73,6 +76,7 @@ describe("Results", (): void => {
     const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#000",
           colorCombos: [],
           isLight: true,
@@ -92,6 +96,7 @@ describe("Results", (): void => {
     const { getByTestId } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#000",
           colorCombos: [],
           isLight: true,
@@ -109,6 +114,7 @@ describe("Results", (): void => {
     const { asFragment } = renderWithRouter(
       <SiteDataProvider
         initialSiteData={{
+          algorithm: "wcag2",
           background: "#000",
           colorCombos: [],
           isLight: true,
@@ -119,5 +125,24 @@ describe("Results", (): void => {
       </SiteDataProvider>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders APCA results without WCAG requirements", (): void => {
+    const { getByText, queryByText } = renderWithRouter(
+      <SiteDataProvider
+        initialSiteData={{
+          algorithm: "apca",
+          background: "#000",
+          colorCombos: [],
+          isLight: true,
+          textColor: "#fff",
+        }}
+      >
+        <Results />
+      </SiteDataProvider>,
+    );
+
+    expect(getByText("APCA Lc")).not.toBeNull();
+    expect(queryByText("AA: 4.5 AAA: 7.0")).toBeNull();
   });
 });

--- a/src/components/results/index.tsx
+++ b/src/components/results/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { useSiteData } from "../../context/home";
-import { colorRating } from "../../utils/color-rating";
+import { getContrastDisplayResult } from "../../utils/contrast-results";
 import {
   ContrastResult,
   ContrastResultDesc,
@@ -30,23 +30,20 @@ const AreYouSerious: React.FC<AreYouSeriousProps> = ({
   );
 };
 
+const wcagRowTestIds: Record<string, string> = {
+  "Bold Text 18px and over": "contrastResult-rating-bold",
+  "Large Text 24px and over": "contrastResult-rating-large",
+  "Small Text": "contrastResult-rating-small",
+};
+
+const getRowTestId = (label: string): string =>
+  wcagRowTestIds[label] ??
+  `contrastResult-rating-${label.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-")}`;
+
 const Results: React.FC = (): ReactElement => {
   const { siteData } = useSiteData();
   const colorInfo = siteData.colorCombos[0].combinations[0];
-  const contrast = colorInfo.contrast || 0;
-  const accessibility = colorInfo.accessibility || {
-    aa: false,
-    aaa: false,
-    aaaLarge: false,
-    aaLarge: false,
-  };
-  const ratio = Number.parseFloat(contrast.toFixed(2));
-  const colorRatings = colorRating(accessibility);
-  const areYouSerious = ratio < 1.3 ? true : undefined;
-  const boldTextRating = colorRatings.bold;
-  const largeTextRating = colorRatings.large;
-  const overallRating = colorRatings.overall;
-  const smallTextRating = colorRatings.small;
+  const result = getContrastDisplayResult(colorInfo, siteData.algorithm, "full");
 
   return (
     <ContrastResults>
@@ -56,43 +53,40 @@ const Results: React.FC = (): ReactElement => {
         as="h1"
         data-testid="contrastResults-heading"
       >
-        {overallRating}
+        {result.heading}
       </ContrastResultsHeading>
+      {result.rows.map((row) => {
+        const description = (
+          <>
+            {row.label}
+            {row.requirement && (
+              <>
+                <br />
+                {row.requirement}
+              </>
+            )}
+          </>
+        );
+        return (
+          <ContrastResult key={row.label}>
+            <ContrastResultDesc isLarge={row.label === "Large Text 24px and over"}>
+              {row.label === "Bold Text 18px and over" ? (
+                <strong>{description}</strong>
+              ) : (
+                description
+              )}
+            </ContrastResultDesc>
+            <ContrastResultRating as="h2" data-testid={getRowTestId(row.label)}>
+              {row.value}
+            </ContrastResultRating>
+          </ContrastResult>
+        );
+      })}
       <ContrastResult>
-        <ContrastResultDesc>
-          Small Text
-          <br />
-          AA: 4.5 AAA: 7.0
-        </ContrastResultDesc>
-        <ContrastResultRating as="h2" data-testid="contrastResult-rating-small">
-          {smallTextRating}
-        </ContrastResultRating>
+        <ContrastResultDesc>{result.metricLabel}</ContrastResultDesc>
+        <ContrastResultRating as="h2">{result.metricValue}</ContrastResultRating>
       </ContrastResult>
-      <ContrastResult>
-        <ContrastResultDesc>
-          <strong>
-            Bold Text 18px and over <br />
-            AA: 3.0 AAA: 4.5
-          </strong>
-        </ContrastResultDesc>
-        <ContrastResultRating as="h2" data-testid="contrastResult-rating-bold">
-          {boldTextRating}
-        </ContrastResultRating>
-      </ContrastResult>
-      <ContrastResult>
-        <ContrastResultDesc isLarge>
-          Large Text 24px and over <br />
-          AA: 3.0 AAA: 4.5
-        </ContrastResultDesc>
-        <ContrastResultRating as="h2" data-testid="contrastResult-rating-large">
-          {largeTextRating}
-        </ContrastResultRating>
-      </ContrastResult>
-      <ContrastResult>
-        <ContrastResultDesc>Contrast Ratio</ContrastResultDesc>
-        <ContrastResultRating as="h2">{`${ratio} : 1`}</ContrastResultRating>
-      </ContrastResult>
-      {areYouSerious && <AreYouSerious isLight={siteData.isLight} />}
+      {result.showSeriously && <AreYouSerious isLight={siteData.isLight} />}
     </ContrastResults>
   );
 };

--- a/src/components/results/index.tsx
+++ b/src/components/results/index.tsx
@@ -61,6 +61,7 @@ const Results: React.FC = (): ReactElement => {
             {row.label}
             {row.requirement && (
               <>
+                {" "}
                 <br />
                 {row.requirement}
               </>

--- a/src/components/results/index.tsx
+++ b/src/components/results/index.tsx
@@ -61,7 +61,7 @@ const Results: React.FC = (): ReactElement => {
             {row.label}
             {row.requirement && (
               <>
-                {" "}
+                {row.label !== "Small Text" && " "}
                 <br />
                 {row.requirement}
               </>

--- a/src/context/home/__tests__/index.spec.tsx
+++ b/src/context/home/__tests__/index.spec.tsx
@@ -1,7 +1,26 @@
 /* eslint-disable react/display-name */
 import * as React from "react";
-import { renderHook, act } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createMemoryHistory, RouterContextProvider } from "@tanstack/react-router";
+import type { HomePageQueryString } from "../../../types";
+import { getRouter } from "../../../router";
+import { parseSiteSearch } from "../../../utils/route-search";
 import { SiteDataProvider, useSiteData, HomeContextInterface } from "..";
+
+const renderSiteDataHook = (initialSiteData?: Partial<HomePageQueryString>, initialEntry = "/") => {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  const router = getRouter();
+  const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
+    <RouterContextProvider history={history} router={router}>
+      <SiteDataProvider initialSiteData={initialSiteData}>{children}</SiteDataProvider>
+    </RouterContextProvider>
+  );
+
+  return {
+    history,
+    ...renderHook((): HomeContextInterface => useSiteData(), { wrapper }),
+  };
+};
 
 const normalizeSiteData = (value: unknown): unknown => {
   if (typeof value === "number") {
@@ -15,7 +34,7 @@ const normalizeSiteData = (value: unknown): unknown => {
   if (value !== null && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .filter(([key]) => key !== "apca")
+        .filter(([key]) => key !== "algorithm" && key !== "apca")
         .map(([key, entry]) => [key, normalizeSiteData(entry)]),
     );
   }
@@ -29,13 +48,8 @@ const expectSiteData = (actual: unknown, expected: unknown): void => {
 
 describe("useSiteData hook", (): void => {
   it("should set context by default", (): void => {
-    const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-      <SiteDataProvider>{children}</SiteDataProvider>
-    );
-
-    const { result } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper,
-    });
+    const { result } = renderSiteDataHook();
+    expect(result.current.siteData.algorithm).toBe("wcag2");
     expectSiteData(result.current.siteData, {
       background: "#1276CE",
       colorCombos: [
@@ -78,19 +92,10 @@ describe("useSiteData hook", (): void => {
   });
 
   it("should set context when initial siteData is set", (): void => {
-    const { result: initialContext } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper: ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-        <SiteDataProvider
-          initialSiteData={{
-            background: "#111",
-            colorCombos: [],
-            isLight: true,
-            textColor: "rgb(239,239,239)",
-          }}
-        >
-          {children}
-        </SiteDataProvider>
-      ),
+    const { result: initialContext } = renderSiteDataHook({
+      background: "#111",
+      isLight: true,
+      textColor: "rgb(239,239,239)",
     });
     expectSiteData(initialContext.current.siteData, {
       background: "#111",
@@ -134,13 +139,7 @@ describe("useSiteData hook", (): void => {
   });
 
   it("should update siteData when background color is changed", (): void => {
-    const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-      <SiteDataProvider>{children}</SiteDataProvider>
-    );
-
-    const { result } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper,
-    });
+    const { result } = renderSiteDataHook();
 
     act((): void => {
       result.current.handleBackgroundColorInputChange("#444");
@@ -188,13 +187,7 @@ describe("useSiteData hook", (): void => {
   });
 
   it("should update siteData when text color is changed", (): void => {
-    const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-      <SiteDataProvider>{children}</SiteDataProvider>
-    );
-
-    const { result } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper,
-    });
+    const { result } = renderSiteDataHook();
     act((): void => {
       result.current.handleTextColorInputChange("#000");
     });
@@ -240,13 +233,7 @@ describe("useSiteData hook", (): void => {
   });
 
   it("should keep current state when invalid colour is set as background color", (): void => {
-    const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-      <SiteDataProvider>{children}</SiteDataProvider>
-    );
-
-    const { result } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper,
-    });
+    const { result } = renderSiteDataHook();
     act((): void => {
       result.current.handleBackgroundColorInputChange("blah");
     });
@@ -293,13 +280,7 @@ describe("useSiteData hook", (): void => {
   });
 
   it("should keep current state when invalid colour is set as textColor color", (): void => {
-    const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-      <SiteDataProvider>{children}</SiteDataProvider>
-    );
-
-    const { result } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper,
-    });
+    const { result } = renderSiteDataHook();
     act((): void => {
       result.current.handleTextColorInputChange("foo");
     });
@@ -345,29 +326,77 @@ describe("useSiteData hook", (): void => {
     });
   });
 
-  it("should handle a text and background colours being the same", (): void => {
-    const { result: sameForeBackContext } = renderHook((): HomeContextInterface => useSiteData(), {
-      wrapper: ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-        <SiteDataProvider
-          initialSiteData={{
-            background: "#fff",
-            colorCombos: [],
-            isLight: true,
-            textColor: "#fff",
-          }}
-        >
-          {children}
-        </SiteDataProvider>
-      ),
+  it("honors a parsed algorithm without color params", (): void => {
+    const { result } = renderSiteDataHook({ algorithm: "apca" });
+    expect(result.current.siteData.algorithm).toBe("apca");
+    expect(result.current.siteData.background).toBe("#1276CE");
+    expect(result.current.siteData.textColor).toBe("#FFFFFF");
+  });
+
+  it("falls back to WCAG for an invalid parsed algorithm", (): void => {
+    const { result } = renderSiteDataHook(parseSiteSearch({ algorithm: "future" }));
+    expect(result.current.siteData.algorithm).toBe("wcag2");
+  });
+
+  it("updates the algorithm and URL without changing colors", async (): Promise<void> => {
+    const initialSiteData = {
+      background: "#000",
+      isLight: false,
+      textColor: "#fff",
+    };
+    const { history, result } = renderSiteDataHook(
+      initialSiteData,
+      "/?background=%23000&isLight=false&textColor=%23fff",
+    );
+    const colorCombos = result.current.siteData.colorCombos;
+
+    act((): void => {
+      result.current.handleAlgorithmChange("apca");
     });
-    expectSiteData(sameForeBackContext.current.siteData, {
+
+    expect(result.current.siteData).toMatchObject({
+      algorithm: "apca",
+      background: "#000",
+      textColor: "#fff",
+    });
+    expect(result.current.siteData.colorCombos).toBe(colorCombos);
+    await waitFor((): void => {
+      const search = new URLSearchParams(history.location.search);
+      expect(search.get("algorithm")).toBe("apca");
+      expect(search.get("background")).toBe("#000");
+      expect(search.get("textColor")).toBe("#fff");
+      expect(search.has("colorCombos")).toBe(false);
+    });
+
+    act((): void => {
+      result.current.handleAlgorithmChange("wcag2");
+    });
+
+    await waitFor((): void => {
+      expect(new URLSearchParams(history.location.search).has("algorithm")).toBe(false);
+    });
+  });
+
+  it("keeps real APCA data when initial colors are equal", (): void => {
+    const { result } = renderSiteDataHook({
+      algorithm: "apca",
       background: "#fff",
-      colorCombos: [
-        { color: [255, 255, 255], combinations: [], hex: "#FFFFFF", model: "rgb", valpha: 1 },
-      ],
       isLight: true,
       textColor: "#fff",
     });
+    expect(result.current.siteData.colorCombos).toHaveLength(2);
+    expect(result.current.siteData.colorCombos[0]?.combinations[0]?.apca?.lc).toBe(0);
+  });
+
+  it("keeps real APCA data when updated colors are equal", (): void => {
+    const { result } = renderSiteDataHook();
+
+    act((): void => {
+      result.current.handleTextColorInputChange("#1276CE");
+    });
+
+    expect(result.current.siteData.colorCombos).toHaveLength(2);
+    expect(result.current.siteData.colorCombos[0]?.combinations[0]?.apca?.lc).toBe(0);
   });
 });
 /* eslint-enable react/display-name */

--- a/src/context/home/index.tsx
+++ b/src/context/home/index.tsx
@@ -163,7 +163,7 @@ const SiteDataProvider: React.FunctionComponent<SiteDataProviderProps> = ({
       }));
       void navigate({
         replace: true,
-        search: (currentSearch) => ({
+        search: (currentSearch: Partial<HomePageQueryString>) => ({
           ...currentSearch,
           algorithm: algorithm === "apca" ? algorithm : undefined,
         }),

--- a/src/context/home/index.tsx
+++ b/src/context/home/index.tsx
@@ -96,7 +96,7 @@ const SiteDataProvider: React.FunctionComponent<SiteDataProviderProps> = ({
   ...props
 }: SiteDataProviderProps): React.ReactElement => {
   const [siteData, setSiteData] = React.useState<SiteData>(setInitialContext(initialSiteData));
-  const navigate = useNavigate();
+  const navigate = useNavigate({ from: "/" });
 
   const updateSearch = React.useCallback(
     (nextState: SiteData): void => {

--- a/src/context/home/index.tsx
+++ b/src/context/home/index.tsx
@@ -157,19 +157,14 @@ const SiteDataProvider: React.FunctionComponent<SiteDataProviderProps> = ({
 
   const handleAlgorithmChange = React.useCallback(
     (algorithm: ContrastAlgorithm): void => {
-      setSiteData((currentState) => ({
-        ...currentState,
+      const nextState = {
+        ...siteData,
         algorithm,
-      }));
-      void navigate({
-        replace: true,
-        search: (currentSearch: Partial<HomePageQueryString>) => ({
-          ...currentSearch,
-          algorithm: algorithm === "apca" ? algorithm : undefined,
-        }),
-      });
+      };
+      setSiteData(nextState);
+      updateSearch(nextState);
     },
-    [navigate],
+    [siteData, updateSearch],
   );
 
   const providerValue = React.useMemo(

--- a/src/context/home/index.tsx
+++ b/src/context/home/index.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
+import { useNavigate } from "@tanstack/react-router";
 import Color from "color";
-import isEmpty from "lodash/isEmpty";
-import debounce from "lodash/debounce";
-import qs from "query-string";
-import ColorCombos, { ColorCombo, Combination } from "color-combos";
-import { SiteData } from "../../types";
+import ColorCombos, { ColorCombo } from "color-combos";
+import { ContrastAlgorithm, HomePageQueryString, SiteData } from "../../types";
 
 export interface HomeContextInterface {
   handleBackgroundColorInputChange: (value: string) => void;
+  handleAlgorithmChange: (algorithm: ContrastAlgorithm) => void;
   handleTextColorInputChange: (value: string) => void;
   siteData: SiteData;
 }
@@ -37,13 +36,18 @@ const isValidColor = (value: string): Color | false => {
   return color;
 };
 
+const getColorCombos = (colors: Array<string>): Array<ColorCombo> => {
+  const combos = ColorCombos(colors, { uniq: false });
+  return combos === false ? [] : combos;
+};
+
 const setInitialContext = (initialSiteData: Partial<SiteData> | undefined): SiteData => {
+  const algorithm = initialSiteData?.algorithm ?? "wcag2";
   let textColor = "#FFFFFF";
   let background = "#1276CE";
   let isLight = false;
   if (
     initialSiteData !== undefined &&
-    !isEmpty(initialSiteData) &&
     typeof initialSiteData.textColor === "string" &&
     typeof initialSiteData.background === "string" &&
     isValidColor(initialSiteData.textColor) &&
@@ -57,31 +61,23 @@ const setInitialContext = (initialSiteData: Partial<SiteData> | undefined): Site
         : checkBackgroundLightness(background);
   }
 
-  const initialCombos = ColorCombos([textColor, background]) as Array<ColorCombo>;
   return {
+    algorithm,
     background,
-    colorCombos: initialCombos,
+    colorCombos: getColorCombos([textColor, background]),
     isLight,
     textColor,
   };
 };
 
-const createFakeCombination = (color: Array<number>, hex: string): Combination => ({
-  accessibility: { aa: false, aaLarge: false, aaa: false, aaaLarge: false },
-  color,
-  contrast: 1,
-  hex,
-  model: "rgb",
-  valpha: 1,
-});
-
-const createDuplicateCombination = (combos: Array<ColorCombo>): Array<ColorCombo> => {
-  const color = combos[0].color === undefined ? [] : combos[0].color;
-  const dupeCombo = {
-    ...combos[0],
-    combinations: [createFakeCombination(color, combos[0].hex)],
+const getHomeSearch = (siteData: SiteData): HomePageQueryString => {
+  const { algorithm, background, isLight, textColor } = siteData;
+  return {
+    ...(algorithm === "apca" ? { algorithm } : {}),
+    background,
+    isLight,
+    textColor,
   };
-  return [dupeCombo, dupeCombo];
 };
 
 // eslint-disable-next-line unicorn/no-useless-undefined
@@ -100,88 +96,90 @@ const SiteDataProvider: React.FunctionComponent<SiteDataProviderProps> = ({
   ...props
 }: SiteDataProviderProps): React.ReactElement => {
   const [siteData, setSiteData] = React.useState<SiteData>(setInitialContext(initialSiteData));
+  const navigate = useNavigate();
 
-  const isInitial = React.useRef<boolean>(false);
-
-  const [state] = React.useMemo(
-    (): [SiteData, React.Dispatch<SiteData>] => [siteData, setSiteData],
-    [siteData],
+  const updateSearch = React.useCallback(
+    (nextState: SiteData): void => {
+      void navigate({
+        replace: true,
+        search: getHomeSearch(nextState),
+      });
+    },
+    [navigate],
   );
-
-  const updateHash = React.useMemo(
-    () =>
-      debounce((nextState: SiteData): void => {
-        const query = `?${qs.stringify({
-          background: nextState.background,
-          colorCombos: nextState.colorCombos,
-          isLight: nextState.isLight,
-          textColor: nextState.textColor,
-        })}`;
-        window.history.pushState(nextState, "Are My Colors Accessible", query);
-      }, 200),
-    [],
-  );
-
-  React.useEffect((): void => {
-    if (isInitial.current) {
-      updateHash(state);
-    } else {
-      isInitial.current = true;
-    }
-  }, [state, updateHash]);
 
   const setNewColorCombo = React.useCallback(
     (textColor: string, backgroundColor: string): void => {
-      let newCombos: Array<ColorCombo> | false = ColorCombos([textColor, backgroundColor]);
-      if (newCombos) {
-        if (textColor === backgroundColor) {
-          newCombos = createDuplicateCombination(newCombos);
-        }
-        setSiteData({
-          ...state,
-          background: backgroundColor,
-          colorCombos: newCombos,
-          isLight: checkBackgroundLightness(backgroundColor),
-          textColor,
-        });
-      }
+      const nextState = {
+        ...siteData,
+        background: backgroundColor,
+        colorCombos: getColorCombos([textColor, backgroundColor]),
+        isLight: checkBackgroundLightness(backgroundColor),
+        textColor,
+      };
+      setSiteData(nextState);
+      updateSearch(nextState);
     },
-    [state],
+    [siteData, updateSearch],
   );
 
   const handleBackgroundColorInputChange = React.useCallback(
     (value: string): void => {
-      setSiteData({
-        ...state,
+      const nextState = {
+        ...siteData,
         background: value,
-      });
+      };
       if (isValidColor(value)) {
-        setNewColorCombo(state.textColor, value);
+        setNewColorCombo(siteData.textColor, value);
+      } else {
+        setSiteData(nextState);
+        updateSearch(nextState);
       }
     },
-    [setNewColorCombo, state],
+    [setNewColorCombo, siteData, updateSearch],
   );
 
   const handleTextColorInputChange = React.useCallback(
     (value: string): void => {
-      setSiteData({
-        ...state,
+      const nextState = {
+        ...siteData,
         textColor: value,
-      });
+      };
       if (isValidColor(value)) {
-        setNewColorCombo(value, state.background);
+        setNewColorCombo(value, siteData.background);
+      } else {
+        setSiteData(nextState);
+        updateSearch(nextState);
       }
     },
-    [setNewColorCombo, state],
+    [setNewColorCombo, siteData, updateSearch],
+  );
+
+  const handleAlgorithmChange = React.useCallback(
+    (algorithm: ContrastAlgorithm): void => {
+      setSiteData((currentState) => ({
+        ...currentState,
+        algorithm,
+      }));
+      void navigate({
+        replace: true,
+        search: (currentSearch) => ({
+          ...currentSearch,
+          algorithm: algorithm === "apca" ? algorithm : undefined,
+        }),
+      });
+    },
+    [navigate],
   );
 
   const providerValue = React.useMemo(
     () => ({
+      handleAlgorithmChange,
       handleBackgroundColorInputChange,
       handleTextColorInputChange,
-      siteData: state,
+      siteData,
     }),
-    [handleBackgroundColorInputChange, handleTextColorInputChange, state],
+    [handleAlgorithmChange, handleBackgroundColorInputChange, handleTextColorInputChange, siteData],
   );
 
   return <HomeContext.Provider value={providerValue} {...props} />;

--- a/src/context/palette/__tests__/index.spec.tsx
+++ b/src/context/palette/__tests__/index.spec.tsx
@@ -764,5 +764,30 @@ describe("usePaletteData hook", (): void => {
       expect(new URLSearchParams(history.location.search).get("algorithm")).toBe("apca");
     });
   });
+
+  it("keeps real APCA data when colors are equal", (): void => {
+    const { result } = renderPaletteDataHook(
+      { algorithm: "apca", colors: ["#fff", "#fff"] },
+      "/palette?algorithm=apca&colors=%23fff&colors=%23fff",
+    );
+    expect(result.current.paletteData.colors).toStrictEqual(["#fff", "#fff"]);
+    expect(result.current.paletteData.colorCombos).toHaveLength(2);
+    expect(result.current.paletteData.colorCombos[0]?.combinations[0]?.apca?.lc).toBe(0);
+  });
+
+  it("keeps real APCA data when a color is updated to match another", (): void => {
+    const { result } = renderPaletteDataHook(
+      { algorithm: "apca", colors: ["#fff", "#000"] },
+      "/palette?algorithm=apca&colors=%23fff&colors=%23000",
+    );
+
+    act((): void => {
+      result.current.handleColorChange("#fff", 1);
+    });
+
+    expect(result.current.paletteData.colors).toStrictEqual(["#fff", "#fff"]);
+    expect(result.current.paletteData.colorCombos).toHaveLength(2);
+    expect(result.current.paletteData.colorCombos[0]?.combinations[0]?.apca?.lc).toBe(0);
+  });
 });
 /* eslint-enable react/display-name */

--- a/src/context/palette/__tests__/index.spec.tsx
+++ b/src/context/palette/__tests__/index.spec.tsx
@@ -1,7 +1,29 @@
 /* eslint-disable react/display-name */
 import * as React from "react";
-import { renderHook, act, RenderHookResult } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createMemoryHistory, RouterContextProvider } from "@tanstack/react-router";
+import type { PalettePageQueryString } from "../../../types";
+import { getRouter } from "../../../router";
+import { parsePaletteSearch } from "../../../utils/route-search";
 import { PaletteDataProvider, usePaletteData, PaletteContextProps } from "..";
+
+const renderPaletteDataHook = (
+  queryString?: Partial<PalettePageQueryString>,
+  initialEntry = "/palette",
+) => {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  const router = getRouter();
+  const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
+    <RouterContextProvider history={history} router={router}>
+      <PaletteDataProvider queryString={queryString}>{children}</PaletteDataProvider>
+    </RouterContextProvider>
+  );
+
+  return {
+    history,
+    ...renderHook((): PaletteContextProps => usePaletteData(), { wrapper }),
+  };
+};
 
 const normalizeContrast = (value: unknown): unknown => {
   if (typeof value === "number") {
@@ -15,7 +37,7 @@ const normalizeContrast = (value: unknown): unknown => {
   if (value !== null && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .filter(([key]) => key !== "apca")
+        .filter(([key]) => key !== "algorithm" && key !== "apca")
         .map(([key, entry]) => [key, normalizeContrast(entry)]),
     );
   }
@@ -27,20 +49,15 @@ const expectPaletteData = (actual: unknown, expected: unknown): void => {
   expect(normalizeContrast(actual)).toEqual(normalizeContrast(expected));
 };
 
-describe("useSiteData hook", (): void => {
-  const wrapper = ({ children }: { children?: React.ReactNode }): React.ReactElement => (
-    <PaletteDataProvider>{children}</PaletteDataProvider>
-  );
-
-  let renderedHook: RenderHookResult<PaletteContextProps, PaletteContextProps>;
+describe("usePaletteData hook", (): void => {
+  let renderedHook: ReturnType<typeof renderPaletteDataHook>;
 
   beforeEach((): void => {
-    renderedHook = renderHook(() => usePaletteData(), {
-      wrapper,
-    });
+    renderedHook = renderPaletteDataHook();
   });
 
   it("should set context by default", (): void => {
+    expect(renderedHook.result.current.paletteData.algorithm).toBe("wcag2");
     expectPaletteData(renderedHook.result.current.paletteData, {
       colorCombos: [],
       colors: [],
@@ -685,6 +702,67 @@ describe("useSiteData hook", (): void => {
     });
     expect(renderedHook.result.current.paletteData.colorCombos).toEqual(coloursCombos);
     expect(renderedHook.result.current.paletteData.hasError).toBeTruthy();
+  });
+
+  it("honors a parsed algorithm without colors", (): void => {
+    const { result } = renderPaletteDataHook({ algorithm: "apca" }, "/palette?algorithm=apca");
+    expect(result.current.paletteData.algorithm).toBe("apca");
+    expect(result.current.paletteData.colors).toStrictEqual([]);
+  });
+
+  it("falls back to WCAG for an invalid parsed algorithm", (): void => {
+    const { result } = renderPaletteDataHook(
+      parsePaletteSearch({ algorithm: "future" }),
+      "/palette?algorithm=future",
+    );
+    expect(result.current.paletteData.algorithm).toBe("wcag2");
+  });
+
+  it("updates the algorithm and URL without changing colors", async (): Promise<void> => {
+    const colors = ["#fff", "#000"];
+    const { history, result } = renderPaletteDataHook(
+      { colors },
+      "/palette?colors=%23fff&colors=%23000",
+    );
+    const colorCombos = result.current.paletteData.colorCombos;
+
+    act((): void => {
+      result.current.handleAlgorithmChange("apca");
+    });
+
+    expect(result.current.paletteData.algorithm).toBe("apca");
+    expect(result.current.paletteData.colors).toStrictEqual(colors);
+    expect(result.current.paletteData.colorCombos).toBe(colorCombos);
+    await waitFor((): void => {
+      const search = new URLSearchParams(history.location.search);
+      expect(search.get("algorithm")).toBe("apca");
+      expect(search.getAll("colors")).toStrictEqual(colors);
+    });
+
+    act((): void => {
+      result.current.handleAlgorithmChange("wcag2");
+    });
+
+    await waitFor((): void => {
+      expect(new URLSearchParams(history.location.search).has("algorithm")).toBe(false);
+    });
+  });
+
+  it("preserves APCA when colors update", async (): Promise<void> => {
+    const { history, result } = renderPaletteDataHook(
+      { algorithm: "apca", colors: ["#fff", "#000"] },
+      "/palette?algorithm=apca&colors=%23fff&colors=%23000",
+    );
+
+    act((): void => {
+      result.current.handleColorChange("#ccc", 0);
+    });
+
+    expect(result.current.paletteData.algorithm).toBe("apca");
+    expect(result.current.paletteData.colors).toStrictEqual(["#ccc", "#000"]);
+    await waitFor((): void => {
+      expect(new URLSearchParams(history.location.search).get("algorithm")).toBe("apca");
+    });
   });
 });
 /* eslint-enable react/display-name */

--- a/src/context/palette/__tests__/index.spec.tsx
+++ b/src/context/palette/__tests__/index.spec.tsx
@@ -736,7 +736,7 @@ describe("usePaletteData hook", (): void => {
     await waitFor((): void => {
       const search = new URLSearchParams(history.location.search);
       expect(search.get("algorithm")).toBe("apca");
-      expect(search.getAll("colors")).toStrictEqual(colors);
+      expect(search.get("colors")).toBe(JSON.stringify(colors));
     });
 
     act((): void => {

--- a/src/context/palette/index.tsx
+++ b/src/context/palette/index.tsx
@@ -1,18 +1,18 @@
 import * as React from "react";
+import { useNavigate } from "@tanstack/react-router";
 import Color from "color";
-import qs from "query-string";
-import isEmpty from "lodash/isEmpty";
-import debounce from "lodash/debounce";
 import ColorCombos, { ColorCombo } from "color-combos";
-import { PalettePageQueryString } from "../../types";
+import { ContrastAlgorithm, PalettePageQueryString } from "../../types";
 
 export interface PaletteContextProps {
+  handleAlgorithmChange: (algorithm: ContrastAlgorithm) => void;
   handleColorChange: (value: string, index: number) => void;
   handleNewColor: (colors: string) => void;
   paletteData: PaletteState;
   setPaletteData: React.Dispatch<React.SetStateAction<PaletteState>>;
 }
-interface PaletteState {
+export interface PaletteState {
+  algorithm: ContrastAlgorithm;
   colorCombos: Array<ColorCombo>;
   colors: Array<string>;
   hasError: boolean;
@@ -64,28 +64,31 @@ const getColorCombos = (colors: Array<string>): Array<ColorCombo> | false => Col
 const getInitialState = (
   querystring: Partial<PalettePageQueryString> | undefined,
 ): PaletteState => {
+  const algorithm = querystring?.algorithm ?? "wcag2";
   let colors: Array<string> = [];
   let colorCombos: Array<ColorCombo> = [];
+  const queryColors = querystring?.colors;
 
-  if (querystring !== undefined && !isEmpty(querystring) && Array.isArray(querystring.colors)) {
-    const initialColorCombos = getColorCombos(querystring.colors);
+  if (Array.isArray(queryColors)) {
+    const initialColorCombos = getColorCombos(queryColors);
     if (initialColorCombos) {
-      colors = querystring.colors;
+      colors = queryColors;
       colorCombos = initialColorCombos;
     }
   }
 
   return {
+    algorithm,
     colorCombos,
     colors,
     hasError: false,
   };
 };
 
-const updateHash = debounce((state): void => {
-  const query = `?${qs.stringify({ colors: state.colors })}`;
-  window.history.pushState(state, "Palette checker - Are My Colours Accessible", query);
-}, 200);
+const getPaletteSearch = (state: PaletteState): PalettePageQueryString => ({
+  ...(state.algorithm === "apca" ? { algorithm: state.algorithm } : {}),
+  colors: state.colors,
+});
 
 // eslint-disable-next-line unicorn/no-useless-undefined
 const PaletteContext = React.createContext<PaletteContextProps | undefined>(undefined);
@@ -103,30 +106,26 @@ const PaletteDataProvider: React.FC<PaletteDataProviderProps> = ({
   queryString,
 }: PaletteDataProviderProps): React.ReactElement => {
   const [paletteData, setPaletteData] = React.useState<PaletteState>(getInitialState(queryString));
+  const navigate = useNavigate({ from: "/palette" });
 
-  const isInitial = React.useRef<boolean>(false);
-
-  const [state] = React.useMemo(
-    (): [PaletteState, React.Dispatch<PaletteState>] => [paletteData, setPaletteData],
-    [paletteData],
+  const updateSearch = React.useCallback(
+    (nextState: PaletteState): void => {
+      void navigate({
+        replace: true,
+        search: getPaletteSearch(nextState),
+      });
+    },
+    [navigate],
   );
-
-  React.useEffect((): void => {
-    if (isInitial.current) {
-      updateHash(state);
-    } else {
-      isInitial.current = true;
-    }
-  }, [state]);
 
   const mergeColorsWithState = React.useCallback(
     (colors: Array<string>): Array<string> => {
       const filteredColors: Array<string> = colors.filter(
-        (color): boolean => !(state.colors as Array<string>).includes(color),
+        (color): boolean => !paletteData.colors.includes(color),
       );
-      return [...state.colors, ...filteredColors];
+      return [...paletteData.colors, ...filteredColors];
     },
-    [state.colors],
+    [paletteData.colors],
   );
 
   const updateColors = React.useCallback(
@@ -134,26 +133,29 @@ const PaletteDataProvider: React.FC<PaletteDataProviderProps> = ({
       let newColorCombos: Array<ColorCombo>;
       if (valid) {
         const combos = getColorCombos(colors);
-        newColorCombos = combos === false ? state.colorCombos : combos;
+        newColorCombos = combos === false ? paletteData.colorCombos : combos;
       } else {
-        newColorCombos = state.colorCombos;
+        newColorCombos = paletteData.colorCombos;
       }
-      setPaletteData({
+      const nextState = {
+        ...paletteData,
         colorCombos: newColorCombos,
         colors,
         hasError: false,
-      });
+      };
+      setPaletteData(nextState);
+      updateSearch(nextState);
     },
-    [state.colorCombos],
+    [paletteData, updateSearch],
   );
 
   const handleColorChange = React.useCallback(
     (value: string, index: number): void => {
-      const newColors: Array<string> = [...state.colors];
+      const newColors: Array<string> = [...paletteData.colors];
       newColors[index] = value;
       updateColors(newColors, !!isValidColor(value));
     },
-    [state.colors, updateColors],
+    [paletteData.colors, updateColors],
   );
 
   const handleNewColor = React.useCallback(
@@ -163,22 +165,35 @@ const PaletteDataProvider: React.FC<PaletteDataProviderProps> = ({
       const mergedColors: Array<string> = mergeColorsWithState(colorsArray);
 
       if (convertedColors === false) {
-        setPaletteData({ ...state, hasError: true });
+        setPaletteData({ ...paletteData, hasError: true });
       } else {
         updateColors(mergedColors, true);
       }
     },
-    [mergeColorsWithState, state, updateColors],
+    [mergeColorsWithState, paletteData, updateColors],
+  );
+
+  const handleAlgorithmChange = React.useCallback(
+    (algorithm: ContrastAlgorithm): void => {
+      const nextState = {
+        ...paletteData,
+        algorithm,
+      };
+      setPaletteData(nextState);
+      updateSearch(nextState);
+    },
+    [paletteData, updateSearch],
   );
 
   const providerValue = React.useMemo(
     () => ({
+      handleAlgorithmChange,
       handleColorChange,
       handleNewColor,
-      paletteData: state,
+      paletteData,
       setPaletteData,
     }),
-    [handleColorChange, handleNewColor, state],
+    [handleAlgorithmChange, handleColorChange, handleNewColor, paletteData],
   );
 
   return <PaletteContext.Provider value={providerValue}>{children}</PaletteContext.Provider>;

--- a/src/context/palette/index.tsx
+++ b/src/context/palette/index.tsx
@@ -59,7 +59,8 @@ const isValidColor = (hex: string): Color | false => {
   return color;
 };
 
-const getColorCombos = (colors: Array<string>): Array<ColorCombo> | false => ColorCombos(colors);
+const getColorCombos = (colors: Array<string>): Array<ColorCombo> | false =>
+  ColorCombos(colors, { uniq: false });
 
 const getInitialState = (
   querystring: Partial<PalettePageQueryString> | undefined,

--- a/src/e2e/homepage.spec.ts
+++ b/src/e2e/homepage.spec.ts
@@ -16,6 +16,8 @@ test.describe("Homepage", () => {
   test("renders the overall rating heading", async ({ page }) => {
     await open(page);
     await expect(page.getByTestId("contrastResults-heading")).toContainText("Yup");
+    await expect(page.getByText("Contrast Ratio")).toBeVisible();
+    await expect(page.getByRole("radio", { name: "WCAG 2.x" })).toBeChecked();
   });
 
   test("renders the default background color", async ({ page }) => {
@@ -32,9 +34,7 @@ test.describe("Homepage", () => {
     await expect(page.getByTestId("contrastResults-heading")).toContainText("Nope");
     await expect
       .poll(() => search(page))
-      .toBe(
-        "?background=%231276CE&colorCombos=%5Bobject%20Object%5D&colorCombos=%5Bobject%20Object%5D&isLight=false&textColor=%23ccc",
-      );
+      .toBe("?background=%231276CE&isLight=false&textColor=%23ccc");
   });
 
   test("updates body color and rating from the background input", async ({ page }) => {
@@ -46,9 +46,7 @@ test.describe("Homepage", () => {
     await expect(page.getByTestId("contrastResults-heading")).toContainText("Nope");
     await expect
       .poll(() => search(page))
-      .toBe(
-        "?background=%23ccc&colorCombos=%5Bobject%20Object%5D&colorCombos=%5Bobject%20Object%5D&isLight=true&textColor=%23FFFFFF",
-      );
+      .toBe("?background=%23ccc&isLight=true&textColor=%23FFFFFF");
   });
 
   test("updates from the text colour lightness slider", async ({ page }) => {
@@ -70,10 +68,7 @@ test.describe("Homepage", () => {
   });
 
   test("renders from query string parameters", async ({ page }) => {
-    await open(
-      page,
-      "/?background=%23B9DDF8&colorCombos=%5Bobject%20Object%5D&colorCombos=%5Bobject%20Object%5D&isLight=true&textColor=%23B25334",
-    );
+    await open(page, "/?background=%23B9DDF8&isLight=true&textColor=%23B25334");
 
     await expect(page.locator("body")).toHaveCSS("background-color", "rgb(185, 221, 248)");
     await expect(page.locator("body")).toHaveCSS("color", "rgb(178, 83, 52)");
@@ -98,6 +93,39 @@ test.describe("Homepage", () => {
     await expect(page.locator("body")).toHaveCSS("background-color", "rgb(0, 0, 0)");
     await expect(page.locator("body")).toHaveCSS("color", "rgb(255, 255, 255)");
     await expect(page.getByTestId("contrastResults-heading")).toContainText("Yup");
+  });
+
+  test("switches to APCA without serializing runtime color combinations", async ({ page }) => {
+    await open(page);
+
+    await page.getByRole("radio", { name: "APCA" }).check();
+
+    await expect(page.getByText("APCA Lc")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("algorithm")).toBe("apca");
+    await expect.poll(() => page.url()).not.toContain("colorCombos=");
+  });
+
+  test("starts in APCA from a color deep link", async ({ page }) => {
+    await open(page, "/?algorithm=apca&textColor=%23fff&background=%23000");
+
+    await expect(page.getByRole("radio", { name: "APCA" })).toBeChecked();
+    await expect(page.getByText("APCA Lc")).toBeVisible();
+  });
+
+  test("keeps an algorithm-only APCA deep link", async ({ page }) => {
+    await open(page, "/?algorithm=apca");
+
+    await expect(page.getByRole("radio", { name: "APCA" })).toBeChecked();
+    await expect(page.getByText("APCA Lc")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("algorithm")).toBe("apca");
+  });
+
+  test("renders equal colors safely in APCA", async ({ page }) => {
+    await open(page, "/?algorithm=apca&textColor=%23777&background=%23777");
+
+    await expect(page.getByTestId("contrastResults-heading")).toContainText("Nope");
+    await expect(page.getByText("APCA Lc")).toBeVisible();
+    await expect(page.getByTestId("contrastResults-seriously")).toHaveText("Seriously?");
   });
 
   test("navigates through footer links", async ({ page }) => {

--- a/src/e2e/palette.spec.ts
+++ b/src/e2e/palette.spec.ts
@@ -2,8 +2,8 @@ import { test, expect, type Page } from "@playwright/test";
 
 const search = (page: Page): string => new URL(page.url()).search;
 
-const open = async (page: Page): Promise<void> => {
-  await page.goto("/palette");
+const open = async (page: Page, path = "/palette"): Promise<void> => {
+  await page.goto(path);
   await page.waitForLoadState("networkidle");
 };
 
@@ -17,6 +17,7 @@ test.describe("Palette", () => {
   test("loads with the correct title", async ({ page }) => {
     await open(page);
     await expect(page).toHaveTitle("Palette checker - Are My Colours Accessible");
+    await expect(page.getByRole("radio", { name: "WCAG 2.x" })).toBeChecked();
   });
 
   test("adds multiple colors to the matrix", async ({ page }) => {
@@ -67,5 +68,25 @@ test.describe("Palette", () => {
     await expect
       .poll(() => search(page))
       .toBe("?colors=orange&colors=%23FF6A00&colors=pink&colors=red");
+  });
+
+  test("switches populated cards to APCA and updates the URL", async ({ page }) => {
+    await open(page);
+    await enterColors(page, "#fff #000");
+    await expect(page.getByTitle("Contrast Ratio")).toHaveCount(2);
+
+    await page.getByRole("radio", { name: "APCA" }).check();
+
+    await expect.poll(() => new URL(page.url()).searchParams.get("algorithm")).toBe("apca");
+    await expect(page.getByTitle("APCA Lc")).toHaveCount(2);
+    await expect(page.getByText(/Body:/).first()).toBeVisible();
+  });
+
+  test("starts populated cards in APCA from a deep link", async ({ page }) => {
+    await open(page, "/palette?colors=%23fff&colors=%23000&algorithm=apca");
+
+    await expect(page.getByRole("radio", { name: "APCA" })).toBeChecked();
+    await expect(page.getByTitle("APCA Lc")).toHaveCount(2);
+    await expect(page.getByText(/Content:/).first()).toBeVisible();
   });
 });

--- a/src/e2e/palette.spec.ts
+++ b/src/e2e/palette.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
 
-const search = (page: Page): string => new URL(page.url()).search;
-
 const open = async (page: Page, path = "/palette"): Promise<void> => {
   await page.goto(path);
   await page.waitForLoadState("networkidle");
@@ -26,7 +24,9 @@ test.describe("Palette", () => {
 
     await expect(page.locator('thead [data-testid="colorMatrix-th"]')).toHaveCount(3);
     await expect(page.locator('tbody [data-testid="colorMatrix-tr"]')).toHaveCount(3);
-    await expect.poll(() => search(page)).toBe("?colors=%23ccc&colors=%23fff&colors=%23000");
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("colors"))
+      .toBe(JSON.stringify(["#ccc", "#fff", "#000"]));
   });
 
   test("shows an error for an invalid color", async ({ page }) => {
@@ -51,7 +51,9 @@ test.describe("Palette", () => {
         'tbody [data-testid="colorMatrix-tr"]:nth-child(1) > [data-testid="colorMatrix-th"]',
       ),
     ).toContainText("#A52A2A");
-    await expect.poll(() => search(page)).toBe("?colors=brown&colors=blue&colors=pink&colors=red");
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("colors"))
+      .toBe(JSON.stringify(["brown", "blue", "pink", "red"]));
   });
 
   test("updates matrix results when the hue slider changes", async ({ page }) => {
@@ -66,8 +68,8 @@ test.describe("Palette", () => {
       ),
     ).toContainText("#FF6A00");
     await expect
-      .poll(() => search(page))
-      .toBe("?colors=orange&colors=%23FF6A00&colors=pink&colors=red");
+      .poll(() => new URL(page.url()).searchParams.get("colors"))
+      .toBe(JSON.stringify(["orange", "#FF6A00", "pink", "red"]));
   });
 
   test("switches populated cards to APCA and updates the URL", async ({ page }) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { ColorCombo } from "color-combos";
 
+export type ContrastAlgorithm = "wcag2" | "apca";
 export type ColorPair = [string, string];
 export interface Levels {
   aa: boolean;
@@ -8,7 +9,15 @@ export interface Levels {
   aaLarge: boolean;
 }
 
+export interface HomePageQueryString {
+  algorithm?: ContrastAlgorithm;
+  background?: string;
+  isLight?: boolean;
+  textColor?: string;
+}
+
 export interface SiteData {
+  algorithm: ContrastAlgorithm;
   background: string;
   colorCombos: Array<ColorCombo>;
   isLight: boolean;
@@ -16,5 +25,6 @@ export interface SiteData {
 }
 
 export interface PalettePageQueryString {
+  algorithm?: ContrastAlgorithm;
   colors: Array<string>;
 }

--- a/src/utils/__tests__/route-search.spec.ts
+++ b/src/utils/__tests__/route-search.spec.ts
@@ -4,11 +4,13 @@ describe("parseSiteSearch", (): void => {
   it("keeps valid shared colour state from route search params", (): void => {
     expect(
       parseSiteSearch({
+        algorithm: "apca",
         background: "#000",
         isLight: "false",
         textColor: "#fff",
       }),
     ).toStrictEqual({
+      algorithm: "apca",
       background: "#000",
       isLight: false,
       textColor: "#fff",
@@ -27,6 +29,18 @@ describe("parseSiteSearch", (): void => {
       textColor: "#fff",
     });
   });
+
+  it.each(["wcag2", "apca"] as const)(
+    "keeps the %s algorithm without color params",
+    (algorithm): void => {
+      expect(parseSiteSearch({ algorithm })).toStrictEqual({ algorithm });
+    },
+  );
+
+  it("ignores invalid and omitted algorithms", (): void => {
+    expect(parseSiteSearch({ algorithm: "future" })).toStrictEqual({});
+    expect(parseSiteSearch({})).toStrictEqual({});
+  });
 });
 
 describe("parsePaletteSearch", (): void => {
@@ -38,5 +52,24 @@ describe("parsePaletteSearch", (): void => {
     expect(parsePaletteSearch({ colors: ["#fff", 123, "#000"] })).toStrictEqual({
       colors: ["#fff", "#000"],
     });
+  });
+
+  it.each(["wcag2", "apca"] as const)(
+    "keeps the %s algorithm without colors",
+    (algorithm): void => {
+      expect(parsePaletteSearch({ algorithm })).toStrictEqual({ algorithm });
+    },
+  );
+
+  it("keeps a valid algorithm with colors", (): void => {
+    expect(parsePaletteSearch({ algorithm: "apca", colors: "#fff" })).toStrictEqual({
+      algorithm: "apca",
+      colors: ["#fff"],
+    });
+  });
+
+  it("ignores invalid and omitted algorithms", (): void => {
+    expect(parsePaletteSearch({ algorithm: "future" })).toStrictEqual({});
+    expect(parsePaletteSearch({})).toStrictEqual({});
   });
 });

--- a/src/utils/color-rating/__tests__/index.spec.ts
+++ b/src/utils/color-rating/__tests__/index.spec.ts
@@ -1,3 +1,5 @@
+import ColorCombos from "color-combos";
+import { getContrastDisplayResult } from "../../contrast-results";
 import { apcaRating } from "../apca-rating";
 import { colorRating } from "../color-rating";
 
@@ -110,5 +112,21 @@ describe("utils/apcaRating", (): void => {
         },
       }).showSeriously,
     ).toBe(expected);
+  });
+
+  it("rates a real Content-pass Body-fail pair as Kinda", (): void => {
+    const colorCombos = ColorCombos(["#ffffff", "#888888"], { uniq: false });
+    if (colorCombos === false) {
+      throw new Error("Expected mid-Lc colors to produce combinations");
+    }
+    const combination = colorCombos[0]?.combinations[0];
+    if (combination?.apca === undefined) {
+      throw new Error("Expected mid-Lc combination to include APCA data");
+    }
+
+    expect(combination.apca.readability.contentText.meets).toBe(true);
+    expect(combination.apca.readability.bodyText.meets).toBe(false);
+    expect(apcaRating(combination.apca).overall).toBe("Kinda");
+    expect(getContrastDisplayResult(combination, "apca", "full").heading).toBe("Kinda");
   });
 });

--- a/src/utils/color-rating/__tests__/index.spec.ts
+++ b/src/utils/color-rating/__tests__/index.spec.ts
@@ -1,3 +1,4 @@
+import { apcaRating } from "../apca-rating";
 import { colorRating } from "../color-rating";
 
 describe("utils/colorRating", (): void => {
@@ -59,5 +60,55 @@ describe("utils/colorRating", (): void => {
       overall: "Nope",
       small: "Fail",
     });
+  });
+});
+
+describe("utils/apcaRating", (): void => {
+  it.each([
+    {
+      contentText: true,
+      expected: "Yup",
+      largeText: true,
+    },
+    {
+      contentText: false,
+      expected: "Kinda",
+      largeText: true,
+    },
+    {
+      contentText: false,
+      expected: "Nope",
+      largeText: false,
+    },
+  ] as const)(
+    "returns $expected from the readability results",
+    ({ contentText, expected, largeText }): void => {
+      expect(
+        apcaRating({
+          lc: 60,
+          readability: {
+            contentText: { meets: contentText, thresholdLc: 60 },
+            largeText: { meets: largeText, thresholdLc: 45 },
+          },
+        }).overall,
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    { expected: true, lc: 14.99 },
+    { expected: true, lc: -14.99 },
+    { expected: false, lc: 15 },
+    { expected: false, lc: -15 },
+  ])("sets showSeriously to $expected for Lc $lc", ({ expected, lc }): void => {
+    expect(
+      apcaRating({
+        lc,
+        readability: {
+          contentText: { meets: false, thresholdLc: 60 },
+          largeText: { meets: false, thresholdLc: 45 },
+        },
+      }).showSeriously,
+    ).toBe(expected);
   });
 });

--- a/src/utils/color-rating/__tests__/index.spec.ts
+++ b/src/utils/color-rating/__tests__/index.spec.ts
@@ -66,28 +66,28 @@ describe("utils/colorRating", (): void => {
 describe("utils/apcaRating", (): void => {
   it.each([
     {
-      contentText: true,
+      bodyText: true,
       expected: "Yup",
       largeText: true,
     },
     {
-      contentText: false,
+      bodyText: false,
       expected: "Kinda",
       largeText: true,
     },
     {
-      contentText: false,
+      bodyText: false,
       expected: "Nope",
       largeText: false,
     },
   ] as const)(
     "returns $expected from the readability results",
-    ({ contentText, expected, largeText }): void => {
+    ({ bodyText, expected, largeText }): void => {
       expect(
         apcaRating({
           lc: 60,
           readability: {
-            contentText: { meets: contentText, thresholdLc: 60 },
+            bodyText: { meets: bodyText, thresholdLc: 75 },
             largeText: { meets: largeText, thresholdLc: 45 },
           },
         }).overall,
@@ -105,7 +105,7 @@ describe("utils/apcaRating", (): void => {
       apcaRating({
         lc,
         readability: {
-          contentText: { meets: false, thresholdLc: 60 },
+          bodyText: { meets: false, thresholdLc: 75 },
           largeText: { meets: false, thresholdLc: 45 },
         },
       }).showSeriously,

--- a/src/utils/color-rating/apca-rating.ts
+++ b/src/utils/color-rating/apca-rating.ts
@@ -1,0 +1,29 @@
+import type { ApcaAccessibility } from "color-combos";
+import type { OverallRating } from "./color-rating";
+
+export interface ApcaRatingInput {
+  lc: ApcaAccessibility["lc"];
+  readability: Pick<ApcaAccessibility["readability"], "contentText" | "largeText">;
+}
+
+export interface ApcaRating {
+  overall: OverallRating;
+  showSeriously: boolean;
+}
+
+const apcaRating = ({ lc, readability }: ApcaRatingInput): ApcaRating => {
+  let overall: OverallRating = "Nope";
+
+  if (readability.contentText.meets) {
+    overall = "Yup";
+  } else if (readability.largeText.meets) {
+    overall = "Kinda";
+  }
+
+  return {
+    overall,
+    showSeriously: Math.abs(lc) < 15,
+  };
+};
+
+export { apcaRating };

--- a/src/utils/color-rating/apca-rating.ts
+++ b/src/utils/color-rating/apca-rating.ts
@@ -3,7 +3,7 @@ import type { OverallRating } from "./color-rating";
 
 export interface ApcaRatingInput {
   lc: ApcaAccessibility["lc"];
-  readability: Pick<ApcaAccessibility["readability"], "contentText" | "largeText">;
+  readability: Pick<ApcaAccessibility["readability"], "bodyText" | "largeText">;
 }
 
 export interface ApcaRating {
@@ -14,7 +14,7 @@ export interface ApcaRating {
 const apcaRating = ({ lc, readability }: ApcaRatingInput): ApcaRating => {
   let overall: OverallRating = "Nope";
 
-  if (readability.contentText.meets) {
+  if (readability.bodyText.meets) {
     overall = "Yup";
   } else if (readability.largeText.meets) {
     overall = "Kinda";

--- a/src/utils/color-rating/color-rating.ts
+++ b/src/utils/color-rating/color-rating.ts
@@ -5,18 +5,21 @@ export interface Accessibility {
   aaLarge: boolean;
 }
 
+export type OverallRating = "Yup" | "Kinda" | "Nope";
+export type WcagRating = "AAA" | "AA" | "Fail";
+
 export interface ColorRating {
-  bold: string;
-  large: string;
-  overall: string;
-  small: string;
+  bold: WcagRating;
+  large: WcagRating;
+  overall: OverallRating;
+  small: WcagRating;
 }
 
 const colorRating = (accessibility: Accessibility): ColorRating => {
-  let small: string;
-  let bold: string;
-  let large: string;
-  let overall = "Nope";
+  let small: WcagRating;
+  let bold: WcagRating;
+  let large: WcagRating;
+  let overall: OverallRating = "Nope";
 
   if (accessibility.aaa) {
     small = "AAA";

--- a/src/utils/color-rating/index.ts
+++ b/src/utils/color-rating/index.ts
@@ -1,5 +1,7 @@
 export { getRating } from "./get-rating";
 export type { GetRatingReturn } from "./get-rating";
 export { colorRating } from "./color-rating";
-export type { ColorRating } from "./color-rating";
+export type { ColorRating, OverallRating, WcagRating } from "./color-rating";
+export { apcaRating } from "./apca-rating";
+export type { ApcaRating, ApcaRatingInput } from "./apca-rating";
 export { ensureColorsAreAnArrayOfTwo } from "./ensure-colors-are-an-array-of-two";

--- a/src/utils/contrast-results/__tests__/index.spec.ts
+++ b/src/utils/contrast-results/__tests__/index.spec.ts
@@ -1,0 +1,160 @@
+import ColorCombos, { type Combination } from "color-combos";
+import { getContrastDisplayResult } from "..";
+
+const colorCombos = ColorCombos(["#fff", "#000"]);
+if (colorCombos === false) {
+  throw new Error("Expected test colors to produce combinations");
+}
+
+const baseCombination = colorCombos[0]?.combinations[0];
+if (baseCombination === undefined) {
+  throw new Error("Expected test combination to include APCA data");
+}
+const baseApca = baseCombination.apca;
+if (baseApca === undefined) {
+  throw new Error("Expected test combination to include APCA data");
+}
+
+const wcagCombination: Combination = {
+  accessibility: {
+    aa: true,
+    aaa: false,
+    aaaLarge: true,
+    aaLarge: true,
+  },
+  contrast: 4.658_034_537_943_552,
+  hex: "#000000",
+};
+
+describe("getContrastDisplayResult", (): void => {
+  it("preserves the full WCAG ratings and ratio", (): void => {
+    expect(getContrastDisplayResult(wcagCombination, "wcag2", "full")).toStrictEqual({
+      heading: "Yup",
+      metricLabel: "Contrast Ratio",
+      metricValue: "4.66 : 1",
+      rows: [
+        {
+          label: "Small Text",
+          meets: true,
+          requirement: "AA: 4.5 AAA: 7.0",
+          value: "AA",
+        },
+        {
+          label: "Bold Text 18px and over",
+          meets: true,
+          requirement: "AA: 3.0 AAA: 4.5",
+          value: "AAA",
+        },
+        {
+          label: "Large Text 24px and over",
+          meets: true,
+          requirement: "AA: 3.0 AAA: 4.5",
+          value: "AAA",
+        },
+      ],
+      showSeriously: false,
+    });
+  });
+
+  it("uses only small and large rows for compact WCAG results", (): void => {
+    expect(getContrastDisplayResult(wcagCombination, "wcag2", "compact").rows).toStrictEqual([
+      { label: "Small", meets: true, value: "AA" },
+      { label: "Large", meets: true, value: "AAA" },
+    ]);
+  });
+
+  it("derives the APCA heading from readability results", (): void => {
+    const combination: Combination = {
+      ...baseCombination,
+      apca: {
+        ...baseApca,
+        lc: 80,
+        readability: {
+          ...baseApca.readability,
+          contentText: {
+            ...baseApca.readability.contentText,
+            meets: false,
+          },
+          largeText: {
+            ...baseApca.readability.largeText,
+            meets: true,
+          },
+        },
+      },
+    };
+
+    const result = getContrastDisplayResult(combination, "apca", "full");
+    expect(result.heading).toBe("Kinda");
+    expect(result.metricLabel).toBe("APCA Lc");
+    expect(result.metricValue).toBe("+80");
+    expect(result.rows.map(({ label }) => label)).toStrictEqual([
+      "Fluent Text",
+      "Body Text",
+      "Content Text",
+      "Large Text",
+      "Minimum Text",
+      "Non-Text",
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(/\bAA(?:A)?\b/);
+  });
+
+  it("uses only Body, Content, and Large rows for compact APCA results", (): void => {
+    const result = getContrastDisplayResult(baseCombination, "apca", "compact");
+    expect(result.rows.map(({ label }) => label)).toStrictEqual(["Body", "Content", "Large"]);
+  });
+
+  it.each([
+    { expected: "+45.68", lc: 45.678 },
+    { expected: "-45.68", lc: -45.678 },
+  ])("formats signed APCA Lc as $expected", ({ expected, lc }): void => {
+    const combination: Combination = {
+      ...baseCombination,
+      apca: {
+        ...baseApca,
+        lc,
+      },
+    };
+    expect(getContrastDisplayResult(combination, "apca", "full").metricValue).toBe(expected);
+  });
+
+  it("keeps Seriously as an overlay at the WCAG boundary", (): void => {
+    expect(
+      getContrastDisplayResult({ ...wcagCombination, contrast: 1.29 }, "wcag2", "full")
+        .showSeriously,
+    ).toBe(true);
+    expect(
+      getContrastDisplayResult({ ...wcagCombination, contrast: 1.3 }, "wcag2", "full")
+        .showSeriously,
+    ).toBe(false);
+  });
+
+  it("keeps Seriously as an overlay at the APCA boundary", (): void => {
+    const getResult = (lc: number) =>
+      getContrastDisplayResult(
+        {
+          ...baseCombination,
+          apca: {
+            ...baseApca,
+            lc,
+          },
+        },
+        "apca",
+        "full",
+      );
+
+    expect(getResult(14.99).showSeriously).toBe(true);
+    expect(getResult(-14.99).showSeriously).toBe(true);
+    expect(getResult(15).showSeriously).toBe(false);
+    expect(getResult(-15).showSeriously).toBe(false);
+  });
+
+  it("returns Unavailable when APCA data is missing", (): void => {
+    expect(getContrastDisplayResult(wcagCombination, "apca", "full")).toStrictEqual({
+      heading: "Unavailable",
+      metricLabel: "APCA Lc",
+      metricValue: "Unavailable",
+      rows: [],
+      showSeriously: false,
+    });
+  });
+});

--- a/src/utils/contrast-results/__tests__/index.spec.ts
+++ b/src/utils/contrast-results/__tests__/index.spec.ts
@@ -71,8 +71,8 @@ describe("getContrastDisplayResult", (): void => {
         lc: 80,
         readability: {
           ...baseApca.readability,
-          contentText: {
-            ...baseApca.readability.contentText,
+          bodyText: {
+            ...baseApca.readability.bodyText,
             meets: false,
           },
           largeText: {

--- a/src/utils/contrast-results/index.ts
+++ b/src/utils/contrast-results/index.ts
@@ -1,0 +1,139 @@
+import type { ApcaAccessibility, Combination } from "color-combos";
+import type { ContrastAlgorithm } from "../../types";
+import { apcaRating, colorRating, type ColorRating, type OverallRating } from "../color-rating";
+
+export type ContrastDisplayVariant = "full" | "compact";
+export type ContrastDisplayHeading = OverallRating | "Unavailable";
+
+export interface ContrastDisplayRow {
+  label: string;
+  meets: boolean;
+  requirement?: string;
+  value: string;
+}
+
+export interface ContrastDisplayResult {
+  heading: ContrastDisplayHeading;
+  metricLabel: "Contrast Ratio" | "APCA Lc";
+  metricValue: string;
+  rows: Array<ContrastDisplayRow>;
+  showSeriously: boolean;
+}
+
+type ReadabilityKey = keyof ApcaAccessibility["readability"];
+
+interface ReadabilityRowDefinition {
+  compactLabel: string;
+  fullLabel: string;
+  key: ReadabilityKey;
+}
+
+const readabilityRows: Array<ReadabilityRowDefinition> = [
+  { compactLabel: "Fluent", fullLabel: "Fluent Text", key: "fluentText" },
+  { compactLabel: "Body", fullLabel: "Body Text", key: "bodyText" },
+  { compactLabel: "Content", fullLabel: "Content Text", key: "contentText" },
+  { compactLabel: "Large", fullLabel: "Large Text", key: "largeText" },
+  { compactLabel: "Minimum", fullLabel: "Minimum Text", key: "minimumText" },
+  { compactLabel: "Non-Text", fullLabel: "Non-Text", key: "nonText" },
+];
+
+const compactReadabilityKeys = new Set<ReadabilityKey>(["bodyText", "contentText", "largeText"]);
+
+const roundMetric = (value: number): number => Number.parseFloat(value.toFixed(2));
+
+const getWcagRows = (
+  rating: ColorRating,
+  variant: ContrastDisplayVariant,
+): Array<ContrastDisplayRow> => {
+  if (variant === "compact") {
+    return [
+      {
+        label: "Small",
+        meets: rating.small !== "Fail",
+        value: rating.small,
+      },
+      {
+        label: "Large",
+        meets: rating.large !== "Fail",
+        value: rating.large,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: "Small Text",
+      meets: rating.small !== "Fail",
+      requirement: "AA: 4.5 AAA: 7.0",
+      value: rating.small,
+    },
+    {
+      label: "Bold Text 18px and over",
+      meets: rating.bold !== "Fail",
+      requirement: "AA: 3.0 AAA: 4.5",
+      value: rating.bold,
+    },
+    {
+      label: "Large Text 24px and over",
+      meets: rating.large !== "Fail",
+      requirement: "AA: 3.0 AAA: 4.5",
+      value: rating.large,
+    },
+  ];
+};
+
+const getApcaRows = (
+  apca: ApcaAccessibility,
+  variant: ContrastDisplayVariant,
+): Array<ContrastDisplayRow> =>
+  readabilityRows
+    .filter(({ key }) => variant === "full" || compactReadabilityKeys.has(key))
+    .map(({ compactLabel, fullLabel, key }) => {
+      const result = apca.readability[key];
+      return {
+        label: variant === "full" ? fullLabel : compactLabel,
+        meets: result.meets,
+        requirement: `|Lc| ≥ ${result.thresholdLc}`,
+        value: result.meets ? "Pass" : "Fail",
+      };
+    });
+
+const getContrastDisplayResult = (
+  combination: Combination,
+  algorithm: ContrastAlgorithm,
+  variant: ContrastDisplayVariant,
+): ContrastDisplayResult => {
+  if (algorithm === "wcag2") {
+    const rating = colorRating(combination.accessibility);
+    const ratio = roundMetric(combination.contrast);
+    return {
+      heading: rating.overall,
+      metricLabel: "Contrast Ratio",
+      metricValue: `${ratio} : 1`,
+      rows: getWcagRows(rating, variant),
+      showSeriously: ratio < 1.3,
+    };
+  }
+
+  if (combination.apca === undefined) {
+    return {
+      heading: "Unavailable",
+      metricLabel: "APCA Lc",
+      metricValue: "Unavailable",
+      rows: [],
+      showSeriously: false,
+    };
+  }
+
+  const rating = apcaRating(combination.apca);
+  const lc = roundMetric(combination.apca.lc);
+  return {
+    heading: rating.overall,
+    metricLabel: "APCA Lc",
+    metricValue: `${lc >= 0 ? "+" : ""}${lc}`,
+    rows: getApcaRows(combination.apca, variant),
+    showSeriously: rating.showSeriously,
+  };
+};
+
+export { getContrastDisplayResult };

--- a/src/utils/route-search.ts
+++ b/src/utils/route-search.ts
@@ -1,8 +1,4 @@
-import type {
-  ContrastAlgorithm,
-  HomePageQueryString,
-  PalettePageQueryString,
-} from "../types";
+import type { ContrastAlgorithm, HomePageQueryString, PalettePageQueryString } from "../types";
 
 const searchString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
@@ -10,9 +6,7 @@ const searchString = (value: unknown): string | undefined =>
 export const isContrastAlgorithm = (value: unknown): value is ContrastAlgorithm =>
   value === "wcag2" || value === "apca";
 
-export const parseSiteSearch = (
-  search: Record<string, unknown>,
-): Partial<HomePageQueryString> => {
+export const parseSiteSearch = (search: Record<string, unknown>): Partial<HomePageQueryString> => {
   const algorithm = search.algorithm;
   const background = searchString(search.background);
   const textColor = searchString(search.textColor);

--- a/src/utils/route-search.ts
+++ b/src/utils/route-search.ts
@@ -1,14 +1,25 @@
-import type { PalettePageQueryString, SiteData } from "../types";
+import type {
+  ContrastAlgorithm,
+  HomePageQueryString,
+  PalettePageQueryString,
+} from "../types";
 
 const searchString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
 
-export const parseSiteSearch = (search: Record<string, unknown>): Partial<SiteData> => {
+export const isContrastAlgorithm = (value: unknown): value is ContrastAlgorithm =>
+  value === "wcag2" || value === "apca";
+
+export const parseSiteSearch = (
+  search: Record<string, unknown>,
+): Partial<HomePageQueryString> => {
+  const algorithm = search.algorithm;
   const background = searchString(search.background);
   const textColor = searchString(search.textColor);
   const isLight = search.isLight;
 
   return {
+    ...(isContrastAlgorithm(algorithm) ? { algorithm } : {}),
     ...(background === undefined ? {} : { background }),
     ...(textColor === undefined ? {} : { textColor }),
     ...(typeof isLight === "boolean"
@@ -22,11 +33,16 @@ export const parseSiteSearch = (search: Record<string, unknown>): Partial<SiteDa
 export const parsePaletteSearch = (
   search: Record<string, unknown>,
 ): Partial<PalettePageQueryString> => {
+  const algorithm = search.algorithm;
   const colors = search.colors;
+  const parsedAlgorithm = isContrastAlgorithm(algorithm) ? { algorithm } : {};
 
   if (Array.isArray(colors)) {
-    return { colors: colors.filter((color): color is string => typeof color === "string") };
+    return {
+      ...parsedAlgorithm,
+      colors: colors.filter((color): color is string => typeof color === "string"),
+    };
   }
 
-  return typeof colors === "string" ? { colors: [colors] } : {};
+  return typeof colors === "string" ? { ...parsedAlgorithm, colors: [colors] } : parsedAlgorithm;
 };


### PR DESCRIPTION
## Why

Users need a shareable way to check the same color pairs under WCAG 2.x or APCA. This PR adds a per-page algorithm toggle on home and palette, keeps WCAG as the default, and stops writing junk `colorCombos=[object Object]` into home URLs.

## Scope

**Shipped**
- `ContrastAlgorithm` (`wcag2` | `apca`) on `SiteData` / palette state and in URL search via `HomePageQueryString` / `PalettePageQueryString`
- Independent `algorithm` parsing in `parseSiteSearch` / `parsePaletteSearch`
- Home and palette contexts persist algorithm with `navigate({ search, replace: true })` and omit `algorithm` when WCAG
- Equal colors use `ColorCombos(..., { uniq: false })` on home and palette; fake/duplicate combination helpers removed
- `apcaRating` beside `colorRating`; `getContrastDisplayResult` for full (Results) and compact (ColorCard) views
- `ContrastAlgorithmToggle` on home and palette, centered under the inputs, with tightened legend spacing and text-style options
- About page documents WCAG vs APCA, Yup/Kinda/Nope mapping, and the shipped Lc readability thresholds
- ColorMatrix formats; ColorCard stays dumb and keeps the row `color` prop
- Playwright coverage for toggle, deep links, equal colors, and cleaned home URLs

**Deferred**
- `/api/are-they` and slash command stay WCAG-only

## Tradeoffs

Algorithm state is per page, not site-wide. Footer navigation can drop `algorithm` unless the URL carries it. That matches color URL state today.

APCA Yup requires Body (`|Lc| ≥ 75`). Content-only or Large-only contrast stays Kinda. That matches the About page and keeps the headline honest for readable body copy.

## Blast Radius

Home Results, home URL writes, palette matrix/cards, About copy, and route search parsing change. Existing WCAG ratings, labels (Yup / Kinda / Nope), and Seriously? overlay behavior stay the default path. API consumers are unchanged.

## Verification

```bash
bun run format:check && bun run lint && bun run test
bun run e2e
```

Format, lint, unit tests, and Playwright tests passed.
